### PR TITLE
🎁 Add collection id to search results

### DIFF
--- a/app/components/ngao/arclight/group_component.html.erb
+++ b/app/components/ngao/arclight/group_component.html.erb
@@ -1,0 +1,43 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to add 'unitid' badge to grouped collections
+%>
+
+<div class='al-grouped-title-bar'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <% if document.repository_config.present? %>
+        <div class='al-grouped-repository breadcrumb-links'>
+          <%= link_to(document.repository_config.name, helpers.arclight_engine.repository_path(document.repository_config.slug)) %>
+        </div>
+      <% end %>
+      <h3><%= helpers.link_to_document document %></h3>
+      <% document.extent.each do |extent| %>
+        <%= tag.span extent, class: 'al-document-extent badge' unless compact? %>
+      <% end %>
+      <%# OVERRIDE begin %>
+      <%= content_tag('span', class: 'al-document-extent badge') do %>
+        Collection ID: <%= document.unitid %>
+      <% end %>
+      <%# OVERRIDE end %>
+      <dl>
+        <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<div class="grouped-documents">
+  <div class="al-grouped-more">
+    <% if @group.total > 3 %>
+      <%= t('arclight.views.index.top_group_results', count: 3) %>
+      <%= link_to(
+        t('arclight.views.index.all_group_results', count: @group.total),
+        search_within_collection_url)
+      %>
+    <% else %>
+      <%= t('arclight.views.index.group_results_count', count: @group.total) %>
+    <% end %>
+  </div>
+
+  <%= helpers.render_document_index @group.docs %>
+</div>

--- a/app/components/ngao/arclight/group_component.rb
+++ b/app/components/ngao/arclight/group_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Add `unitid` badge to groupeed collections
+
+module Ngao
+  module Arclight
+    class GroupComponent < ::Arclight::GroupComponent
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -64,7 +64,7 @@ class CatalogController < ApplicationController
     config.index.title_field = 'normalized_title_ssm'
     config.index.display_type_field = 'level_ssm'
     config.index.document_component = Arclight::SearchResultComponent
-    config.index.group_component = Arclight::GroupComponent
+    config.index.group_component = Ngao::Arclight::GroupComponent
     config.index.constraints_component = Arclight::ConstraintsComponent
     config.index.document_presenter_class = Arclight::IndexPresenter
     config.index.search_bar_component = Arclight::SearchBarComponent


### PR DESCRIPTION
# Story

This commit will add the collection id (`unitid`) to the search results.
when viewing in the `Grouped by collection` view.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/23

# Screenshots / Video

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/739130c6-e1cd-4db7-bb1d-9265b3cbaf94">

