### PR TITLE
💄 Make breadcrumb styling padding left more even

### DIFF
--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,5 +1,8 @@
 // Override breadcrumb heirarchy styles from arclight
 
+$base-padding: 0.5rem;
+$padding-increment: 0.5rem;
+
 .al-show-breadcrumb {
   .breadcrumb {
     svg {
@@ -18,16 +21,22 @@
     }
 
     .breadcrumb-item-1 {
-      padding-left: 1rem;
+      padding-left: $base-padding;
+
+      .breadcrumb {
+        padding-left: $base-padding;
+      }
     }
 
-    .breadcrumb-item-2 {
-      .breadcrumb {
-        padding-left: 1rem;
+    @for $i from 3 through 8 {
+      .breadcrumb-item-3:nth-child(#{$i}) {
+        padding-left: calc(#{$base-padding} + #{$padding-increment * ($i - 2)});
+      }
+    }
 
-        li:last-child:not(:first-child) {
-          padding-left: 1rem;
-        }
+    @for $i from 2 through 8 {
+      .breadcrumb-item-3:nth-of-type(#{$i}) ~ li.breadcrumb-item-4 {
+        padding-left: calc(#{$base-padding} + #{$padding-increment * ($i - 1)});
       }
     }
 


### PR DESCRIPTION
Prior to this commit, the padding left was inconsistent and when we got deep into the nested breadcrumbs, the padding would not account for the situtation.  This commit will make the styling a little more dynamic in that it will adjust the padding based on the number of nested `.breadcrumb-item-3` elements.  The draw back is that you still would need to adjust the number of nested elements if things get super deep. Right now I set it to 8, anything beyond that would look wonky and would require the upper number to be bumped up.

### Before
<img width="489" alt="image" src="https://github.com/user-attachments/assets/3bb4e7d6-68b8-453d-85a1-36565c2713be">

### After
<img width="498" alt="image" src="https://github.com/user-attachments/assets/80f21a2f-b6a3-44a7-91b5-c4e12a8363c8">
