### PR TITLE
💄 Revert breadcrumbs styling to default ArcLight

### DIFF
--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,4 +1,4 @@
-// Override breadcrumb heirarchy styles from arclight
+// Add breadcrumb heirarchy styles to arclight
 
 .al-show-breadcrumb {
   .breadcrumb {
@@ -6,29 +6,6 @@
       height: 1rem;
       width: 1rem;
       fill: #6E757C;
-    }
-
-    .breadcrumb-item:first-of-type::before,
-    .breadcrumb-item + .breadcrumb-item::before {
-      content: '';
-    }
-
-    .breadcrumb-item {
-      display: block;
-    }
-
-    .breadcrumb-item-1 {
-      padding-left: 1rem;
-    }
-
-    .breadcrumb-item-2 {
-      .breadcrumb {
-        padding-left: 1rem;
-
-        li:last-child:not(:first-child) {
-          padding-left: 1rem;
-        }
-      }
     }
 
     .breadcrumb-campus-link {

--- a/app/components/ngao/arclight/breadcrumbs_hierarchy_component.html.erb
+++ b/app/components/ngao/arclight/breadcrumbs_hierarchy_component.html.erb
@@ -7,36 +7,36 @@
   <li class="breadcrumb-home-link">
     <%= link_to t('arclight.routes.home'), root_path %>
   </li>
+  <%# OVERRIDE begin %>
   <li class="breadcrumb-campus-link">
     <span aria-hidden="true"><%= blacklight_icon :campus, classes: 'al-collection-content-icon' %></span>
     <span class="breadcrumb-text"><%= @campus %></span>
   </li>
+  <%# OVERRIDE end %>
   <li class="breadcrumb-item breadcrumb-item-1">
     <span aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>
     <span class="breadcrumb-text"><%= repository %></span>
     <ol class="breadcrumb">
       <% if collection %>
         <li class="breadcrumb-item breadcrumb-item-2">
-          <span aria-hidden="true"><%= blacklight_icon 'arrow-return-right', classes: 'al-collection-content-icon' %></span>
+          <span aria-hidden="true"><%= blacklight_icon :collection, classes: 'al-collection-content-icon' %></span>
           <span class="breadcrumb-text"><%= link_to collection.label, solr_document_path(collection.id) %></span>
 
           <ol class="breadcrumb">
             <% parents_under_collection.each do |parent| %>
               <li class="breadcrumb-item breadcrumb-item-3">
-                <span aria-hidden="true"><%= blacklight_icon 'arrow-return-right', classes: 'al-collection-content-icon' %></span>
                 <span class="breadcrumb-text"><%= link_to parent.label, solr_document_path(parent.id) %></span>
               </li>
             <% end %>
 
             <li class="breadcrumb-item breadcrumb-item-4">
-              <span aria-hidden="true"><%= blacklight_icon 'arrow-return-right', classes: 'al-collection-content-icon' %></span>
-              <span class="breadcrumb-text"><%= @presenter.heading %></span>
+             <span class="breadcrumb-text"><%= @presenter.heading %></span>
             </li>
           </ol>
         </li>
       <% else # this is a collection %>
         <li class="breadcrumb-item breadcrumb-item-4">
-          <span aria-hidden="true"><%= blacklight_icon 'arrow-return-right', classes: 'al-collection-content-icon' %></span>
+          <span aria-hidden="true"><%= blacklight_icon :collection, classes: 'al-collection-content-icon' %></span>
           <span class="breadcrumb-text"><%= @presenter.heading %></span>
         </li>
       <% end %>


### PR DESCRIPTION
This commit will revert the styling for the breadcrumbs to default ArcLight for now.  We will assess if this needs to change or not at a later point.  Also added an obvious comment to what we overrode in the breadcrumbs_hierarchy_component partial.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/ce984763-99b3-45c5-875b-f5db70b92c29">
