### PR TITLE
I20 custom homepage

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -6,3 +6,12 @@ $logo-image: image_url('arclight/logo.png') !default;
 @import 'breadcrumbs';
 @import 'campus';
 @import 'scroll_to_top';
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+#main-container {
+  flex: 1 0 auto;
+}

--- a/app/assets/stylesheets/brand.css
+++ b/app/assets/stylesheets/brand.css
@@ -1,0 +1,143 @@
+#branding-bar,
+#footer {
+  -webkit-font-smoothing: initial;
+  -moz-font-smoothing: initial;
+  font-smoothing: initial;
+}
+
+#branding-bar *,
+#footer * {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+#branding-bar .row,
+#footer .row {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  max-width: 64rem;
+  position: relative;
+}
+
+#branding-bar .row:before, #branding-bar .row:after,
+#footer .row:before,
+#footer .row:after {
+  content: " ";
+  display: table;
+}
+
+#branding-bar .row:after,
+#footer .row:after {
+  clear: both;
+}
+
+#branding-bar .row.pad,
+#footer .row.pad {
+  padding-left: 0.9375rem;
+  padding-right: 0.9375rem;
+  width: 100%;
+}
+
+#footer {
+  padding: 24px 0;
+  text-align: center;
+  position: relative;
+  font-family: BentonSansRegular, Arial, serif;
+  font-weight: normal;
+}
+
+#footer a {
+  color: #990000;
+}
+
+#footer a:focus {
+  outline: .125rem solid #990000;
+  outline-offset: .125rem;
+}
+
+#footer .signature {
+  text-align: center;
+}
+
+#footer .signature-link {
+  background: url("iu-sig-formal.svg") no-repeat left top;
+  background-size: contain;
+  display: inline-block;
+  height: 0;
+  padding-top: 36px;
+  overflow: hidden;
+  width: 240px;
+}
+
+#footer .signature-link.signature-img {
+  background-image: none;
+  height: auto;
+  width: 15rem;
+  padding-top: 0;
+}
+
+#footer p {
+  font-size: 0.75rem;
+  line-height: 24px;
+  margin: 0;
+  clear: left;
+}
+
+#footer .row {
+  display: flex;
+  justify-content: center;
+}
+
+@media screen and (max-width: 350px) {
+  #footer .line-break-small {
+    display: block;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  #footer .line-break {
+    display: block;
+  }
+  #footer .hide-on-mobile {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 40em) {
+  /* Campus names */
+  #branding-bar .show-on-tablet {
+    display: inline;
+  }
+  #branding-bar .show-on-mobile,
+  #branding-bar .show-on-desktop {
+    display: none;
+  }
+  #footer {
+    text-align: left;
+    border-top: 6px solid #7A1705;
+    padding: 32px 0 24px;
+    margin-top: 16px;
+  }
+  #footer p {
+    line-height: 2.25rem;
+  }
+  #footer .footer-links {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+  #footer .signature {
+    float: left;
+    text-align: left;
+    height: 36px;
+  }
+  #footer .copyright {
+    float: right;
+    clear: right;
+    text-align: right;
+  }
+}

--- a/app/assets/stylesheets/iu_variables.scss
+++ b/app/assets/stylesheets/iu_variables.scss
@@ -1,0 +1,5 @@
+$iu-crimson: #990000;
+$iu-mahogany: #4A3C31;
+$iu-cream: #EDEBEB;
+$iu-white: #FFF;
+$iu-grey: #A9A9A9;

--- a/app/assets/stylesheets/ngao-footer.scss
+++ b/app/assets/stylesheets/ngao-footer.scss
@@ -1,0 +1,43 @@
+@import "iu_variables";
+
+#ngao-footer {
+  width: 100%;
+  margin: 0 auto;
+  background-color: $iu-mahogany;
+  display: flex;
+  .ngao-links {
+    margin: 0 auto;
+    position: relative;
+    justify-content: space-around;
+  }
+}
+
+.link-caddy {
+  ul {
+    list-style-type: none;
+    li {
+      display: inline-flex;
+      a {
+        color: $iu-cream;
+        padding: 0.5rem 1rem;
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+.link-caddy {
+  a:hover {
+    color: $iu-cream;
+    text-decoration: none;
+  }
+}
+
+@media only screen and (min-width:40em) {
+  #ngao-footer {
+    padding: 1rem 0;
+  }
+  #footer {
+    margin-top: 0px;
+  }
+}

--- a/app/components/blacklight/search_navbar_component.html.erb
+++ b/app/components/blacklight/search_navbar_component.html.erb
@@ -1,0 +1,12 @@
+<%#
+  OVERRIDE Blacklight v8.3.0 to add 'Get search help' link to navbar
+%>
+
+<%= tag.div class: 'navbar-search navbar navbar-light bg-light', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
+  <div class="<%= container_classes %>">
+    <%= search_bar %>
+    <%# OVERRIDE begin %>
+    <%= link_to 'Get search help', help_path %>
+    <%# OVERRIDE end %>
+  </div>
+<% end %>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  def about; end
+
+  def contribute; end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,6 @@ class PagesController < ApplicationController
   def about; end
 
   def contribute; end
+
+  def help; end
 end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,5 @@
+<% @page_title = t('arclight.views.about.title') %>
+<div>
+  <h2>About Archives Online</h2>
+  <p>Indiana University (IU) Bloomington Libraries, with support from the Indiana University Office of the Bicentennial, and in close collaboration with the <a href="https://uisapp2.iu.edu/confluence-prd/x/uYTYHg">Archives Online Working Group</a>, made up of representatives across the IU campuses, developed and implemented a shared set of best practices, workflows, and software to facilitate the management, description, digitization, digital preservation, and discovery of archival and special collections for all IU campuses. Motivated by decreasing barriers for description and digitization and increasing access to our students and scholars, Indiana University adopted <a href="https://archivesspace.org/">ArchivesSpace</a> for managing/creating archival and special collections, and collaboratively developed <a href="https://library.stanford.edu/projects/arclight">ArcLight</a>, initiated by Stanford University Libraries, for the discovery and delivery of collection descriptions/finding aids.</p>
+</div>

--- a/app/views/pages/contribute.html.erb
+++ b/app/views/pages/contribute.html.erb
@@ -1,0 +1,7 @@
+<% @page_title = t('arclight.views.contribute.title') %>
+<div>
+  <h2>Contribute to Archives Online</h2>
+  <p>Email <a href="mailto:diglib@indiana.edu">diglib@indiana.edu</a> to setup an introductory consultation to Archives Online. Members of the Digital Collections Services team from the IU Libraries Bloomington will be able to help you with managing/description or the delivery/discovery of your finding aids.</p>
+
+<p>Visit the <a href="https://uisapp2.iu.edu/confluence-prd/x/uYTYHg">Archives Online Working Group</a> wiki to review best practices and related documentation. </p>
+</div>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,0 +1,63 @@
+<% @page_title = t('arclight.views.help.title') %>
+<div>
+  <h2>Help with Archives Online</h2>
+  <h3>All Fields Options</h3>
+  <p>
+    <span style="font-style:italic; font-weight:bold">Collections</span> include records from Indiana University repositories. You can search across all collections (finding aids) or search within an individual collection. The All Fields drop-down menu for Archives Online searching allows users to narrow their search even further.
+  </p>
+  <ul>
+    <li>
+      You can search by <span style="font-style:italic; font-weight:bold">Keyword</span> to find a specific word or phrase represented anywhere in a collection's finding aid.
+    </li>
+    <li>
+      You can search by <span style="font-style:italic; font-weight:bold">Name</span> to find a specific person's name represented in a collection's finding aid.
+    </li>
+    <li>
+      You can search by <span style="font-style:italic; font-weight:bold">Place</span> to find a specific locations represented in a collection's finding aid.
+    </li>
+    <li>
+      Each collection has been assigned a number of subjects to describe the materials in the collection. A <span style="font-style:italic; font-weight:bold">Subject</span> search is similar to a keyword search, but instead of searching through the entire finding aid you are searching the assigned subjects of each collection.
+    </li>
+    <li>
+      You can search by <span style="font-style:italic; font-weight:bold">Title</span> to find a specific collection in Archives Online. 
+    </li>
+  </ul>
+  <h3>Advanced Searching</h3>
+  <h4>Shout Your Boolean</h4>
+  <p>
+    To optimize your search, you can use Boolean operators in the search bar. Boolean operators are simple words (<span style="font-weight:bold">AND</span> and <span style="font-weight:bold">NOT</span>) used as conjunctions to combine or exclude keywords in a search. Doing so results in more focused and productive results. Using Boolean operators should save time and effort by eliminating inappropriate hits. Please note that Boolean operators must be entered in ALL CAPS to be recognized by the system - shout your Boolean!
+  </p>
+  <p>
+    <span style="font-weight:bold">AND</span>—Both terms must be represented in a collection. If one term is contained in the document and the other is not, the item is not included in the resulting list. You would use AND if you are trying to narrow your search.
+    <br/>
+    <span style="font-style:italic">Example:</span> A keyword search for <span style="font-weight:bold">love AND baseball</span> will only return collections that represent both terms. A collection that includes the term "love" but not the term "baseball" will not be included in the resulting list. 
+  </p>
+	<p>
+		<span style="font-weight:bold">OR</span>—Either term must be represented in a collection. If one term or another is contained in a document, the item will be included in the results list. You would use OR if you're trying to expand your search.
+		<br/>
+		<span style="font-style:italic">Example:</span> A keyword search for <span style="font-weight:bold">love OR baseball</span> will return collections that represent one or both of the terms. A collection that includes the term "love" but not the term "baseball" will be included in the resulting list. The same is true if a collection includes the "baseball" but not the term "love."
+	</p>
+  <p>
+    <span style="font-weight:bold">NOT</span>—the first term is searched, then any records containing the term after the operators are subtracted from the results. You would use NOT if you're trying to limit your search.
+    <br/>
+    <span style="font-style:italic">Example:</span> A place search for <span style="font-weight:bold">love NOT baseball</span> would exclude all hits for "love" that also included "baseball." 
+  </p>
+  <h4>Exact Phrase and Wildcard Searching</h4>
+  <p>
+    <span style="font-weight:bold">Helpful hints:</span> Use quotation marks around search terms greater than one word. When you surround your search terms with quotation marks, you are telling the database that the words must appear as an exact phrase. Otherwise, each word in your search term will be searched separately, broadening your search.
+    <br/>
+    <span style="font-style:italic">Example:</span> <span style="font-weight:bold">Indiana University</span> yields more results than <span style="font-weight:bold">"Indiana University"</span> in quotation marks because in the first search, Archives Online is looking for every collection that contains "Indiana" AND "University" AND "Indiana University."
+  </p>
+  <p>
+    You can use wildcards (<span style="font-weight:bold">?</span>, <span style="font-weight:bold">*</span>) for searching as well.
+  <br/>
+	<span style="font-style:italic">Examples:</span> <span style="font-weight:bold">base*</span> returns results with "bases" or "based" or "baseball." <span style="font-weight:bold">wom?n</span> returns results with "woman" or "women."
+  </p>
+	<h4>Searching by Repository</h4>
+	<p>
+		Begin with any search in the search bar at the top of the page. Once on the results list, click on the <span style="font-weight:bold">"Repository"</span> facet on the left hand side of the screen. Click on the repository you want to search within. The results list will now exclude hits from all repositories besides the one you selected.
+	</p>
+	<p>
+		<span style="font-style:italic">Example: </span>The results list from a keyword search for <span style="font-weight:bold">love AND baseball</span> faceted by Lilly Library will only include Lilly Library collections that contain the terms "love" and "baseball."
+	</p>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,2 @@
+<%= render 'shared/ngao_footer'%>
+<%= render 'shared/iu_footer'%>

--- a/app/views/shared/_iu_footer.html.erb
+++ b/app/views/shared/_iu_footer.html.erb
@@ -1,0 +1,15 @@
+<!--imported from https://assets.iu.edu/brand/3.2.x/footer.html with modifications for image-->
+<footer id="footer" role="contentinfo" itemscope="itemscope" itemtype="http://schema.org/CollegeOrUniversity">
+  <div class="row pad">
+    <div class="footer-links">
+      <p class="signature">
+        <a href="https://www.iu.edu" class="signature-link signature-img"><img src="//assets.iu.edu/brand/3.2.x/iu-sig-formal.svg" alt="Indiana University"></a>
+      </p>
+      <p class="copyright">
+        <span class="line-break"><a href="https://accessibility.iu.edu/assistance" id="accessibility-link" title="Having trouble accessing this web page content? Please visit this page for assistance.">Accessibility</a> | <a href="https://libraries.indiana.edu/privacy" id="privacy-policy-link">Privacy Notice</a></span>
+        <span class="hide-on-mobile"> | </span>
+        <a href="https://www.iu.edu/copyright/index.html">Copyright</a> © 2020 <span class="line-break-small">The Trustees of <a href="https://www.iu.edu/" itemprop="url"><span itemprop="name">Indiana University</span></a></span>
+      </p>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_ngao_footer.html.erb
+++ b/app/views/shared/_ngao_footer.html.erb
@@ -1,0 +1,10 @@
+<footer id="ngao-footer">
+  <div class="row pad ngao-links">
+    <div class="link-caddy">
+      <ul>
+        <%= render 'shared/static_pages_links' %>
+        <%= render 'shared/user_auth_links' %>
+      </ul>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_static_pages_links.html.erb
+++ b/app/views/shared/_static_pages_links.html.erb
@@ -1,4 +1,4 @@
-<%# <li class="nav-item ml-3"> <%= link_to 'About', about_path, class: 'nav-link' %></li>
-<%# <li class="nav-item ml-3"> <%= link_to 'Contribute to AO', contribute_path, class: 'nav-link' %></li>
+<li class="nav-item ml-3"> <%= link_to 'About', about_path, class: 'nav-link' %></li>
+<li class="nav-item ml-3"> <%= link_to 'Contribute to AO', contribute_path, class: 'nav-link' %></li>
 <%# template for adding new links, just copy and remove the <%#
 <%# <li class="nav-item ml-3"> <% link_to 'Label', path_to_link, class: 'nav-link' %></li>

--- a/app/views/shared/_static_pages_links.html.erb
+++ b/app/views/shared/_static_pages_links.html.erb
@@ -1,0 +1,4 @@
+<%# <li class="nav-item ml-3"> <%= link_to 'About', about_path, class: 'nav-link' %></li>
+<%# <li class="nav-item ml-3"> <%= link_to 'Contribute to AO', contribute_path, class: 'nav-link' %></li>
+<%# template for adding new links, just copy and remove the <%#
+<%# <li class="nav-item ml-3"> <% link_to 'Label', path_to_link, class: 'nav-link' %></li>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -1,0 +1,20 @@
+<% if current_user %>
+  <li class="nav-item ml-3"><a class="nav-link" href="https://libraries.indiana.edu/harmful-language-statement">Harmful Language Statement</a></li>
+  <li class="nav-item ml-3">
+    <%= link_to "Admin", admin_path, class: 'nav-link' %>
+  </li>
+  <li class="nav-item ml-3">
+    <% if ENV['AL_AUTHN'] == 'database' %>
+      <%= link_to "Logout", destroy_user_session_path, class: 'nav-link' %>
+    <% else %>
+      <%= link_to "Logout", destroy_global_session_path, class: 'nav-link' %>
+    <% end %>
+  </li>
+  <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
+<% else %>
+  <li class="nav-item ml-3"><a class="nav-link" href="https://libraries.indiana.edu/harmful-language-statement">Harmful Language Statement</a></li>
+  <li class="nav-item ml-3">
+    <%#= link_to "Admin", admin_path, class: 'nav-link' %>
+  </li>
+  <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
+<% end %>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -10,11 +10,11 @@
       <%= link_to "Logout", destroy_global_session_path, class: 'nav-link' %>
     <% end %>
   </li>
-  <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
+  <%# <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li> %> 
 <% else %>
   <li class="nav-item ml-3"><a class="nav-link" href="https://libraries.indiana.edu/harmful-language-statement">Harmful Language Statement</a></li>
   <li class="nav-item ml-3">
     <%#= link_to "Admin", admin_path, class: 'nav-link' %>
   </li>
-  <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
+  <%# <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li> %>
 <% end %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,4 +1,22 @@
 en:
+  arclight:
+    masthead_heading: Archives Online
+    views:
+      about:
+        title: About - Archives Online at Indiana University
+      home:
+        title: Archives Online at Indiana University
+      contribute:
+        title: Contribute - Archives Online at Indiana University
+      help:
+        title: Help - Archives Online at Indiana University
+      repositories:
+        show: "%{name} - Archives Online at Indiana University"
+        title: Repositories - Archives Online at Indiana University
+        view_all_collections: "View all %{count} collections"
+      show:
+        expand: "items above"
+        collapse: "items below"
   blacklight:
     search:
       fields:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  get '/about', to: 'pages#about', as: 'about'
+  get '/contribute', to: 'pages#contribute', as: 'contribute'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,11 +28,10 @@ Rails.application.routes.draw do
   ##### REMOVE BOOKMARK #####
   # resources :bookmarks do
   #   concerns :exportable
-
-    collection do
-      delete 'clear'
-    end
-  end
+  #   collection do
+  #     delete 'clear'
+  #   end
+  # end
 
   get '/about', to: 'pages#about', as: 'about'
   get '/contribute', to: 'pages#contribute', as: 'contribute'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
 
   get '/about', to: 'pages#about', as: 'about'
   get '/contribute', to: 'pages#contribute', as: 'contribute'
+  get '/help', to: 'pages#help', as: 'help'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
# Story

IU has a custom homepage with static content links. The archives_online application should have the same.

Refs:
- [ ] https://github.com/scientist-softserv/archives_online/issues/20

# Expected Behavior Before Changes

There was no footer and no links to About page or Contribute page. There was no `Get search help` link or corresponding Help page.

# Expected Behavior After Changes

The footer exists with custom branding that matches the current production site. There are link for the About and Contribute pages that take the use to the appropriate static pages. There is a `Get search help` link in the search area and a corresponding Help page.

# Screenshots / Video

https://github.com/user-attachments/assets/b3ba7318-2693-45c2-b9db-85228a1a3f06

# Testing Notes

- The user can click the `Get search help` link and be taken to the Help page.
- The footer exists on the home page with custom branding. 
- The user can click the `About` link and be taken to the About page.
- The user can click the `Contribute to AO` link and be taken to the Contribution page.
