### PR TITLE
🎁 Remove search history route

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,8 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
   include Blacklight::LocalePicker::Concern
   layout :determine_layout if respond_to? :layout
+
+  def render404
+    raise ActionController::RoutingError, 'Not Found'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  ##### REMOVE SEARCH HISTORY #####
+  # Note: has to be before we mount Blacklight::Engine
+  get '/search_history', to: 'application#render404'
+  delete '/search_history/clear', to: 'application#render404'
+
   mount Blacklight::Engine => '/'
   mount Arclight::Engine => '/'
 


### PR DESCRIPTION
This commit will block the search_history routes from being accessed by users that are crafty enough to navigate to them directly.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/22

<img width="619" alt="image" src="https://github.com/user-attachments/assets/7262b95e-3240-4de1-be5f-ea3a8669aa85">
