### PR TITLE
⚙️ Configure `ead2_config` and `CatalogController`

### DIFF
--- a/data/softserv_VAD9218.xml
+++ b/data/softserv_VAD9218.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
   <eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="edited-full-draft"
     langencoding="iso639-2b" repositoryencoding="iso15511">
-    <eadid url="https://archives.iu.edu/catalog/ohrc110">VAD9218</eadid>
+    <eadid countrycode="US" mainagencycode="US-InU">VAD9218</eadid>
     <filedesc>
       <titlestmt>
         <titleproper>Donald E. Hattin Media Materials<date normal="1959/2016"> 1959/2016</date>
@@ -131,6 +131,10 @@
       <head>File Plan</head>
       <p>file plan note</p>
     </fileplan>
+    <odd id="aspace_6f89501d873f54b4de298f0878e77e9f">
+      <head>General</head>
+      <p>general note</p>
+    </odd>
     <acqinfo id="aspace_46240bac0c07eaee8a3c4cb51c2450d9">
       <head>Immediate Source of Acquisition</head>
       <p>immediate source of acquisition note</p>


### PR DESCRIPTION
# Story

This commit brings over a lot from NGAO but I hesitate to copy it directly since a lot of the changes are either not relevant or are already the way Arclight does things.  I did the logic for the `context.clipboard[:repository]` in the `ead2_config` file to look for the campus if the REPOSITORY_ID wasn't provided which might be useful in this time of transition.  This could be reverted back after we hand this project back to IU.

A lot of the issues that came from the reviewing of the EAD implementation should be fixed in this commit.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/45
- https://github.com/scientist-softserv/archives_online/issues/46
- https://github.com/scientist-softserv/archives_online/issues/47
- https://github.com/scientist-softserv/archives_online/issues/48

# Expected Behavior Before Changes

The collection show and index pages were pretty much stock Arclight.

# Expected Behavior After Changes

Now the collection show and index are more customized for IU's use case.

- EAD indexing will automatically find the campus it should belong to if `REPOSITORY_ID` wasn't passed in.
  - NOTE:  This has not been widely tested but will serve us for our staging set up at least.
- The `ead2_config` has been updated with this [commit](https://github.com/projectblacklight/arclight/commit/373ce44ae4aa0ae3523e750d60632488de6a9631).
- The `softserv_VAD9218.xml` test data has been corrected by adding a `mainagencycode`.
- The `CatalogController` is closer aligned with the NGAO's version.
  - `Component Identifier`, which pulls from `unitid`, now appears on the show.
  - `Bibliography` now shows.
  - `Other descriptive data` has been changed to `General note`.

# Screenshots / Video

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/15b26ddd-e084-4ed1-ad17-9a8bc4ea115f">

<img width="614" alt="image" src="https://github.com/user-attachments/assets/0b78817f-a99d-40db-a60e-86f3f7a69e0d">

# Notes

These changes may require a reindex.
```sh
DIR=data rake arclight:index_dir
```