### PR TITLE
🐛 Fix solr fields for facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -145,15 +145,15 @@ class CatalogController < ApplicationController
     # :index_range can be an array or range of prefixes that will be used to create the navigation
     #  (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'campus_unit_sim', label: 'Campus', helper_method: :render_campus_facet
-    config.add_facet_field 'repository_sim', label: 'Repository', limit: 10
-    config.add_facet_field 'collection_sim', label: 'Collection', limit: 10
-    config.add_facet_field 'level_sim', label: 'Level', limit: 10
+    config.add_facet_field 'campus_unit_ssim', label: 'Campus', helper_method: :render_campus_facet
+    config.add_facet_field 'repository_ssim', label: 'Repository', limit: 10
+    config.add_facet_field 'collection_ssim', label: 'Collection', limit: 10
+    config.add_facet_field 'level_ssim', label: 'Level', limit: 10
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
-    config.add_facet_field 'geogname_sim', label: 'Place', limit: 10
+    config.add_facet_field 'geogname_ssim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'parent_ssim', show: false


### PR DESCRIPTION
This commit will adjust the solr field to what they are indexed to in this application's ead2_config.  Originally, the fields were brought in from NGAO and it didn't match up exactly.  Ex. `repository_sim` vs `repository_ssim`.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/19

<img width="708" alt="image" src="https://github.com/user-attachments/assets/86214221-6c37-408f-81ec-bd438e1d6643">
