### PR TITLE
I53 blacklight range limit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/BlockLength:
     - 'lib/tasks/*.rake'
     - 'test/**/*'
     - 'app/controllers/catalog_controller.rb'
+    - 'config/environments/development.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -74,8 +74,8 @@ group :test do
   gem 'selenium-webdriver'
 end
 gem 'arclight'
-
 gem 'blacklight-locale_picker'
+gem 'blacklight_range_limit'
 gem 'bootstrap', '~> 5.1'
 gem 'devise'
 gem 'devise-guests', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
       view_component (>= 2.66, < 4)
     blacklight-locale_picker (1.2.0)
       rails (>= 5.2.3, < 7.3)
+    blacklight_range_limit (8.5.0)
+      blacklight (>= 7.25.2, < 9)
+      deprecation
+      view_component (>= 2.54, < 4)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     bootstrap (5.3.3)
@@ -357,7 +361,7 @@ GEM
     unf (0.2.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    view_component (3.13.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -383,6 +387,7 @@ PLATFORMS
 DEPENDENCIES
   arclight
   blacklight-locale_picker
+  blacklight_range_limit
   bootsnap
   bootstrap (~> 5.1)
   capybara

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,9 @@
  *
  *= require_tree .
  *= require_self
- */
+ 
+ *
+ * Used by blacklight_range_limit
+ *= require  'blacklight_range_limit'
+ *
+*/

--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -15,3 +15,18 @@ body {
 #main-container {
   flex: 1 0 auto;
 }
+
+// OVERRIDE Blacklight Range Limit gem because it doesn't seem to work with Rails 7/Blacklight 8
+// @see https://github.com/projectblacklight/blacklight_range_limit/issues/236
+#facet-date_range_isim {
+  // Hide some features that don't work or we don't want
+  .distribution, .more_facets, .facet-values.missing, .facet-count {
+    display: none;
+  }
+  p.range.subsection {
+    .facet-limit-active & {
+      // Don't show the complete date range if one is already applied
+      display: none;
+    }
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@
 # Blacklight controller that handles searches and document requests
 class CatalogController < ApplicationController
   include Blacklight::Catalog
+  include BlacklightRangeLimit::ControllerOverride
   include Arclight::Catalog
   include Arclight::FieldConfigHelpers
 
@@ -152,6 +153,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
+    config.add_facet_field 'date_range_isim', label: 'Year', range: { assumed_boundaries: [0, Time.now.year + 2] }
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
     config.add_facet_field 'geogname_ssim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,7 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightRangeLimit::RangeLimitBuilder
   include Arclight::SearchBehavior
 
   ##

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,7 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  # config.assets.debug = true
+  config.web_console.allowed_ips = ['172.18.0.0/16', '172.27.0.0/16', '0.0.0.0/0']
+
+  config.assets.debug = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   ##### REMOVE SEARCH HISTORY #####
   # Note: has to be before we mount Blacklight::Engine
   get '/search_history', to: 'application#render404'
@@ -14,6 +15,7 @@ Rails.application.routes.draw do
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
+    concerns :range_searchable
   end
   devise_for :users
 


### PR DESCRIPTION
# Story

## 🎁 Install Blaclight Range Limit gem

e64ec528d42cc0e4bc448717252fc5ad7f9f94fe

This commit adds the Blacklight Range Limit gem and minor changes to
make it work.  The assets are currently not working yet though.

## 💄 Hiding a lot of the UI from range facet

f02ec7470ee4c4f493d332990056bac2f7972438

It seems that Blacklight Range Limit and Rails 7/Blacklight 8 don't work
well together.  The javascript does not seem to be working properly.
I've hidden the UI for the parts that don't work for now borrowing from
Standford's Arclight solution.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/53
- https://github.com/projectblacklight/blacklight_range_limit/issues/236
- https://github.com/sul-dlss/stanford-arclight/pull/529

# Expected Behavior Before Changes

Year facet was not present.

# Expected Behavior After Changes

Year facet is now present but features like the chart and the slider are not working with Rails 7/Blacklight 8.

# Screenshots / Video

<img width="501" alt="image" src="https://github.com/user-attachments/assets/df7f42a5-78ac-4eb8-abf6-008df35944fe">

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/8bb84582-55a4-4f71-b708-6a36fbd0fc19">
