### PR TITLE
💄 I26 styling collection show page

### DIFF
--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -159,37 +159,87 @@
 }
 
 // REPOSITORIES
-.al-repositories {
-  .repositories {
-    .al-repository {
-      @extend .rvt-card--horizontal, .rvt-card--raised;
 
-      margin-bottom: 1.5rem !important;
-      border: unset;
+%al-repository-styles {
+  @extend .rvt-card--horizontal, .rvt-card--raised;
 
-      .container {
-        img {
-          border-radius: .25rem;
-        }
+  margin-bottom: 1.5rem !important;
+  border: unset;
 
-        all: unset;
+  .container {
+    img {
+      border-radius: .25rem;
+    }
 
-        .al-repository-information {
-          .repo-name {
-            @extend .rvt-card__title;
+    all: unset;
 
-            a::before {
-              display: none;
-            }
-          }
+    .al-repository-information {
+      .repo-name {
+        @extend .rvt-card__title;
 
-          .al-repository-extra a.btn-secondary {
-            @extend .rvt-button--secondary;
-
-            font-weight: var(--rvt-font-weight-medium);
-          }
+        a::before {
+          display: none;
         }
       }
+
+      .al-repository-extra a.btn-secondary {
+        @extend .rvt-button--secondary;
+
+        font-weight: var(--rvt-font-weight-medium);
+      }
+    }
+  }
+}
+
+.blacklight-repositories-index {
+  .al-repository {
+    @extend %al-repository-styles;
+  }
+}
+
+.blacklight-repositories-show {
+  section {
+    margin-bottom: 4rem;
+  }
+
+  .al-repository {
+    @extend %al-repository-styles;
+  }
+
+  .al-repository-show-header {
+    div {
+      margin-top: 2rem;
+
+      h2 {
+        font-size: 1.75rem;
+      }
+    }
+
+    .text-right {
+      @extend .rvt-card;
+
+      display: flex;
+      align-items: end;
+      justify-content: center;
+
+      .al-repository-collections {
+        display: flex;
+
+        &::after {
+          display: none;
+        }
+
+        a {
+          @extend .rvt-cta
+        }
+      }
+    }
+  }
+
+  .al-document-title-bar {
+    .row .al-collection-id {
+      display: flex;
+      justify-content: end;
     }
   }
 }

--- a/app/helpers/arclight_helper_decorator.rb
+++ b/app/helpers/arclight_helper_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# OVERRIDE Arclight v1.4.0 helper methods
+
+module ArclightHelperDecorator
+  def repository_collections_path(repository)
+    search_action_url(
+      f: {
+        repository_ssim: [repository.name],
+        level_ssim: ['Collection']
+      },
+      group: true
+    )
+  end
+end
+
+ArclightHelper.prepend(ArclightHelperDecorator)


### PR DESCRIPTION
# Story

## 💄 Style collection show page

fe090a47378fd714fa4b1f92ab46dff1a7b9ac30

This commit will style the collection show page with Rivet styles.

## 🐛 Fix route for collection show

faf4d4e951e0a5f837361dbd20023c179e0d8095

The `View all of our collections` link was not working correctly because
it was using default Arclight params.  This commit will add the correct
params to the link.

Ref:
- #26 

# Expected Behavior Before Changes
Styles on the collection show page was stock Arclight/Blaclight.  The `View all of our collections` link did not go to the correct faceted search.

# Expected Behavior After Changes
Rivet styles are applied to the collection show page.  The `View all of our collections` link now goes to the correct faceted search.

# Screenshots / Video

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/88564972-663c-407c-8a02-249182aee654">
