### PR TITLE
💄 Styles for static pages

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = t('arclight.views.about.title') %>
 <div>
-  <h2>About Archives Online</h2>
+  <h2 class="rvt-ts-lg rvt-m-bottom-md rvt-m-top-sm">About Archives Online</h2>
   <p>Indiana University (IU) Bloomington Libraries, with support from the Indiana University Office of the Bicentennial, and in close collaboration with the <a href="https://uisapp2.iu.edu/confluence-prd/x/uYTYHg">Archives Online Working Group</a>, made up of representatives across the IU campuses, developed and implemented a shared set of best practices, workflows, and software to facilitate the management, description, digitization, digital preservation, and discovery of archival and special collections for all IU campuses. Motivated by decreasing barriers for description and digitization and increasing access to our students and scholars, Indiana University adopted <a href="https://archivesspace.org/">ArchivesSpace</a> for managing/creating archival and special collections, and collaboratively developed <a href="https://library.stanford.edu/projects/arclight">ArcLight</a>, initiated by Stanford University Libraries, for the discovery and delivery of collection descriptions/finding aids.</p>
 </div>

--- a/app/views/pages/contribute.html.erb
+++ b/app/views/pages/contribute.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t('arclight.views.contribute.title') %>
 <div>
-  <h2>Contribute to Archives Online</h2>
+  <h2 class="rvt-ts-lg rvt-m-bottom-md rvt-m-top-sm">Contribute to Archives Online</h2>
   <p>Email <a href="mailto:diglib@indiana.edu">diglib@indiana.edu</a> to setup an introductory consultation to Archives Online. Members of the Digital Collections Services team from the IU Libraries Bloomington will be able to help you with managing/description or the delivery/discovery of your finding aids.</p>
 
 <p>Visit the <a href="https://uisapp2.iu.edu/confluence-prd/x/uYTYHg">Archives Online Working Group</a> wiki to review best practices and related documentation. </p>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = t('arclight.views.help.title') %>
 <div>
-  <h2>Help with Archives Online</h2>
-  <h3>All Fields Options</h3>
+  <h2 class="rvt-ts-lg rvt-m-bottom-md rvt-m-top-sm">Help with Archives Online</h2>
+  <h3 class="rvt-ts-md rvt-m-bottom-sm">All Fields Options</h3>
   <p>
     <span style="font-style:italic; font-weight:bold">Collections</span> include records from Indiana University repositories. You can search across all collections (finding aids) or search within an individual collection. The All Fields drop-down menu for Archives Online searching allows users to narrow their search even further.
   </p>
@@ -22,8 +22,8 @@
       You can search by <span style="font-style:italic; font-weight:bold">Title</span> to find a specific collection in Archives Online. 
     </li>
   </ul>
-  <h3>Advanced Searching</h3>
-  <h4>Shout Your Boolean</h4>
+  <h3 class="rvt-ts-md rvt-m-bottom-sm">Advanced Searching</h3>
+  <h4 class="rvt-ts-sm rvt-m-bottom-xs rvt-text-medium">Shout Your Boolean</h4>
   <p>
     To optimize your search, you can use Boolean operators in the search bar. Boolean operators are simple words (<span style="font-weight:bold">AND</span> and <span style="font-weight:bold">NOT</span>) used as conjunctions to combine or exclude keywords in a search. Doing so results in more focused and productive results. Using Boolean operators should save time and effort by eliminating inappropriate hits. Please note that Boolean operators must be entered in ALL CAPS to be recognized by the system - shout your Boolean!
   </p>
@@ -42,7 +42,7 @@
     <br/>
     <span style="font-style:italic">Example:</span> A place search for <span style="font-weight:bold">love NOT baseball</span> would exclude all hits for "love" that also included "baseball." 
   </p>
-  <h4>Exact Phrase and Wildcard Searching</h4>
+  <h4 class="rvt-ts-sm rvt-m-bottom-xs rvt-text-medium">Exact Phrase and Wildcard Searching</h4>
   <p>
     <span style="font-weight:bold">Helpful hints:</span> Use quotation marks around search terms greater than one word. When you surround your search terms with quotation marks, you are telling the database that the words must appear as an exact phrase. Otherwise, each word in your search term will be searched separately, broadening your search.
     <br/>
@@ -53,7 +53,7 @@
   <br/>
 	<span style="font-style:italic">Examples:</span> <span style="font-weight:bold">base*</span> returns results with "bases" or "based" or "baseball." <span style="font-weight:bold">wom?n</span> returns results with "woman" or "women."
   </p>
-	<h4>Searching by Repository</h4>
+	<h4 class="rvt-ts-sm rvt-m-bottom-xs rvt-text-medium">Searching by Repository</h4>
 	<p>
 		Begin with any search in the search bar at the top of the page. Once on the results list, click on the <span style="font-weight:bold">"Repository"</span> facet on the left hand side of the screen. Click on the repository you want to search within. The results list will now exclude hits from all repositories besides the one you selected.
 	</p>


### PR DESCRIPTION
This commit adds Rivet utility classes to the static pages: About, Contribute, and Help.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/e3b495d7-5566-40c7-8e58-5fe72fca66e8">

<img width="676" alt="image" src="https://github.com/user-attachments/assets/94cc4e6a-f1df-446e-8dac-b8973196be1e">

<img width="644" alt="image" src="https://github.com/user-attachments/assets/7c14631a-04d9-421b-a221-a9d17b2dc72b">

Ref:
- #26 

