### PR TITLE
I26 styling collection show

### DIFF
--- a/app/assets/images/rivet_icons/arrow-anchor-down-right.svg
+++ b/app/assets/images/rivet_icons/arrow-anchor-down-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#6E757C" viewBox="0 0 16 16">
+  <path d="M1 2h2v8h8.586L9.793 8.207l1.414-1.414L15.414 11l-4.207 4.207-1.414-1.414L11.586 12H1V2Z"/>
+</svg>

--- a/app/assets/images/rivet_icons/info-circle-solid.svg
+++ b/app/assets/images/rivet_icons/info-circle-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+  <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm7-3a1 1 0 1 0 2 0 1 1 0 0 0-2 0Zm2 2H7v5h2V7Z"/>
+</svg>

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -414,4 +414,12 @@
       }
     }
   }
+
+  #collection-nav {
+    margin-top: .75rem;
+  }
+
+  .al-sidebar-navigation-context a {
+    @extend .rvt-link;
+  }
 }

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -479,7 +479,7 @@
       margin-left: 2rem;
     }
 
-    .breadcrumb-item-3:first-of-type::before, 
+    .breadcrumb-item-3:first-of-type::before,
     .breadcrumb-item-4:first-child > .breadcrumb-text:first-child::before {
       content: image-url('rivet_icons/arrow-anchor-down-right.svg');
       margin-left: .5rem;
@@ -499,5 +499,11 @@
     .breadcrumb-item a {
       margin-right: 0.5rem;
     }
-  } 
+  }
+
+  .al-request {
+    .btn-primary {
+      @extend .rvt-button;
+    }
+  }
 }

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -244,6 +244,43 @@
   }
 }
 
+%paginate-section {
+  margin-top: 1.5rem;
+
+  .pagination {
+    @extend .rvt-pagination;
+
+    .page-item {
+      @extend .rvt-pagination__item;
+
+      height: inherit;
+      width: inherit;
+
+      .page-link {
+        border-color: transparent;
+        border-radius: 0;
+        margin: 0 1px 0 -1px;
+        padding-left: .775rem;
+        padding-right: .775rem;
+        border: 0;
+      }
+
+      .page-link[aria-current=true] {
+        background-color: #fff3f0;
+        box-shadow: 0 .25rem 0 #900;
+        color: inherit;
+      }
+
+      &.disabled {
+        .page-link {
+          background: unset;
+          color: #6E757C;
+        }
+      }
+    }
+  }
+}
+
 // SEARCH RESULTS PAGE
 .blacklight-catalog-index {
   .btn-primary {
@@ -327,42 +364,7 @@
   }
 
   .record-padding {
-    .paginate-section {
-      margin-top: 1.5rem;
-
-      .pagination {
-        @extend .rvt-pagination;
-
-        .page-item {
-          @extend .rvt-pagination__item;
-
-          height: inherit;
-          width: inherit;
-
-          .page-link {
-            border-color: transparent;
-            border-radius: 0;
-            margin: 0 1px 0 -1px;
-            padding-left: .775rem;
-            padding-right: .775rem;
-            border: 0;
-          }
-
-          .page-link[aria-current=true] {
-            background-color: #fff3f0;
-            box-shadow: 0 .25rem 0 #900;
-            color: inherit;
-          }
-
-          &.disabled {
-            .page-link {
-              background: unset;
-              color: #A2ABB3;
-            }
-          }
-        }
-      }
-    }
+    @extend %paginate-section;
   }
 
   .document-metadata {
@@ -505,5 +507,9 @@
     .btn-primary {
       @extend .rvt-button;
     }
+  }
+
+  .record-padding {
+    @extend %paginate-section;
   }
 }

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -432,4 +432,72 @@
       border-radius: .25rem;
     }
   }
+
+  .breadcrumb {
+    a {
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    .breadcrumb-home-link {
+      a[href="/"] {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        top: .25rem;
+
+        &::before {
+          content: "";
+          display: inline-block;
+          width: 16px;
+          height: 16px;
+          background-image: image-url('rivet_icons/home.svg');
+          background-size: contain;
+          background-repeat: no-repeat;
+          margin-right: 0.25rem;
+        }
+
+        &:hover::before {
+          filter: invert(60%) sepia(100%) saturate(1400%) hue-rotate(195deg) brightness(50%) contrast(130%);
+        }
+
+        &::after {
+          content: "Home"; /* Matches the orignial text content */
+          position: absolute;
+          left: -9999px; /* Moves the text off-screen */
+          visibility: visible; /* Keeps the text readable by screen readers */
+        }
+      }
+    }
+
+    .breadcrumb-campus-link {
+      margin-left: 1rem;
+    }
+
+    .breadcrumb-item-1 {
+      margin-left: 2rem;
+    }
+
+    .breadcrumb-item-3:first-of-type::before, 
+    .breadcrumb-item-4:first-child > .breadcrumb-text:first-child::before {
+      content: image-url('rivet_icons/arrow-anchor-down-right.svg');
+      margin-left: .5rem;
+      margin-right: .25rem;
+    }
+
+    .breadcrumb-item + .breadcrumb-item {
+      padding-left: 0;
+
+      &::before {
+        content: '/';
+        padding-right: 0.5rem;
+        color: var(--rvt-color-black-200);
+      }
+    }
+
+    .breadcrumb-item a {
+      margin-right: 0.5rem;
+    }
+  } 
 }

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -422,4 +422,14 @@
   .al-sidebar-navigation-context a {
     @extend .rvt-link;
   }
+
+  #appliedParams {
+    .btn-primary {
+      @extend .rvt-button;
+    }
+    .btn-outline-secondary {
+      @extend .rvt-button--secondary;
+      border-radius: .25rem;
+    }
+  }
 }

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -369,3 +369,49 @@
     @extend %breadcrumb-styles;
   }
 }
+
+// SHOW PAGE
+.blacklight-catalog-show {
+  .al-collection-context-actions .dropdown {
+    @extend .rvt-dropdown;
+
+    button {
+      @extend .rvt-button--secondary;
+
+      &::after {
+        width: 1rem;
+        height: 1rem;
+        background-image: image-url('rivet_icons/chevron-down.svg');
+        border: none;
+        position: relative;
+        top: .375rem;
+      }
+
+      .bi-info-circle-fill {
+        background-image: image-url('rivet_icons/info-circle-solid.svg');
+        fill: none;
+        position: relative;
+        bottom: 3px;
+      }
+    }
+
+    .dropdown-menu {
+      @extend .rvt-dropdown__menu;
+
+      min-width: 9rem;
+
+      .dropdown-item {
+        display: flex;
+        align-items: center;
+
+        svg {
+          margin-right: .25rem;
+        }
+      }
+
+      &.dropdown-menu.shadow-lg.p-2.show {
+        min-width: 21.25rem !important;
+      }
+    }
+  }
+}

--- a/data/softserv_InU-Li-VAE1866.xml
+++ b/data/softserv_InU-Li-VAE1866.xml
@@ -1,0 +1,9565 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="originaldraft"
+    langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-InU">InU-Li-VAE1866</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Miscellaneous mss., <date normal="0001/1992" era="ce" calendar="gregorian">2100
+            BCE-1992</date>
+          <num>LMC 1754</num>
+          <num>LMC 1754</num></titleproper>
+        <subtitle>Papers of Various at the Lilly Library, Indiana University, Bloomington,
+          Indiana</subtitle>
+        <author>Electronic finding aid encoded by Indiana University Libraries.</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>Lilly Library</publisher>
+        <p id="logostmt"><extref xlink:actuate="onLoad"
+            xlink:href="http://webapp1.dlib.indiana.edu/archivesOnline/repositoryImages/lilly.png"
+            xlink:show="embed" xlink:type="simple"/></p>
+        <p><date>© 2020</date></p>
+        <address>
+          <addressline>1200 E. Seventh St.</addressline>
+          <addressline>Bloomington, Indiana 47405-5500</addressline>
+          <addressline>Business Number: 812-855-2452</addressline>
+          <addressline>liblilly@indiana.edu</addressline>
+          <addressline>URL: <extptr xlink:href="https://libraries.indiana.edu/lilly-library"
+              xlink:show="new" xlink:title="https://libraries.indiana.edu/lilly-library"
+              xlink:type="simple"/></addressline>
+        </address>
+      </publicationstmt>
+      <notestmt>
+        <note>
+          <p><date normal="2020">© 2020</date> Trustees of Indiana University. All rights
+            reserved.</p>
+        </note>
+      </notestmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2024-09-03 16:06:22
+          -0400</date>.</creation>
+      <langusage>Description is in English.</langusage>
+    </profiledesc>
+    <revisiondesc>
+      <change audience="internal">
+        <date>May 14, 2020</date>
+        <item>Encoded finding aid created by Ava Dickerson.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Lilly Library</corpname>
+      </repository>
+      <unittitle>Miscellaneous mss.</unittitle>
+      <origination label="Creator">
+        <persname source="ingest">Various</persname>
+      </origination>
+      <unitid>LMC 1754</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">12 boxes 61 bound</extent>
+      </physdesc>
+      <unitdate calendar="gregorian" datechar="creation" era="ce" normal="0001/1992"
+        type="inclusive">2100 BCE-1992</unitdate>
+      <abstract id="aspace_18f40f4189e44abe2ed47851fbaad7c8">The Miscellaneous mss., 2100 BCE-1970,
+        consist of individual items acquired individually either as a gift or purchased from a
+        variety of sources.</abstract>
+      <physloc audience="internal" id="aspace_b9355a85c7051adfac7f6a2acf590594">Lilly - Stacks;
+        Lilly - Map Case; Lilly - Vault 2 (Box 12); ALF (Auxiliary Library Facility) (Box 13, 14,
+        15, 16)</physloc>
+      <langmaterial id="aspace_9610d0bf957920c2190cb68361f53f51">Materials are in multiple
+        languages, including <language langcode="eng">English</language>, <language langcode="fre"
+          >French</language>, <language langcode="spa">Spanish</language>, <language langcode="ita"
+          >Italian</language>, and <language langcode="ger">German.</language></langmaterial>
+    </did>
+    <accessrestrict id="aspace_a47a0a8dea658af50cfdfd8d938f628d">
+      <head>Access Restrictions</head>
+      <p>This collection is open for research.</p>
+      <p>Many collections are housed offsite; retrieval requires advance notice. Please <extref
+          xlink:href="https://libraries.indiana.edu/lilly-library/ask">make an appointment</extref>
+        a minimum of one week in advance of your visit.</p>
+    </accessrestrict>
+    <bioghist id="aspace_6d8223010956d0c6e8659ce2247fb2f4">
+      <head>Historical Note</head>
+      <p>The materials in this collection represent a very wide variety of time periods and
+        geographic regions. Please see individual descriptions for more information.</p>
+    </bioghist>
+    <scopecontent id="aspace_4039dce633e96eddd6dcdcc46792020a">
+      <head>Scope and Content Note</head>
+      <p>Note on Indexing Term - "Law": Of particular interest: Apr. 13, 1640-Mar. 28, 1681: Great
+        Britain, Parliament, House of Commons, Journals. Oct. 21-Dec. 30, 1678. Great Britain,
+        Parliament. House of Commons. Journal Book of the House of Commons for the Sessions of
+        Parliament begun at Westminster... 1723. Majmuai fetawa (Legal decisions) written by 'Ali
+        ibn Mustafþ. 18th cent. Huccatlar (Legal opinions of judges on land tenure law in
+        Turkey).</p>
+      <p> Note on Indexing Term - "Medicine": Of particular interest are the following: 1652, Mar.
+        8. al-Qanun fi al-Tibb (The canon of medicine) by Avicenna, physician. 1730?. Extract from
+        the Pen-ts'ao chang-mu by Li Chi Tsin [written by Jacques Francois Vandermonde, physician.]
+        This item discusses the practice of Chinese medicine. 1780-1829. Compendium of Physic and
+        Surgery, attributed to Joseph Flowerden, published London, 1769. n.d. Manafai ' al-nas
+        written by Nida'i, head medicine man of Sultan Salim II. It deals with medicine in Turkey
+        during the 16th century.</p>
+      <p> Note on Indexing Term - "Music": Of particular interest is a 1884-1909 album of
+        autographs, signatures, and letters of musicians and others. Many of the autographs are
+        accompanied by bars of music.</p>
+      <p> Note on Indexing Term - "Voyages and travels": Of interest are the following items: Jan.
+        24, 1587: Passport granting safe conduct to St. John of Lisbon, Portuguese ship, sailing to
+        Brazil for a cargo of sugar, wood, etc. Nov. 16, 1652-Sept. 20, 1653: "Naval affairs, &amp;
+        the Dutch war in K. Charles ye 2d's reign..." written by Sir John Lawson. Aug. 15, 1683:
+        Letter from Governor of Jamaica, Sir Thomas Lynch to Charles II, King of Britain. Concerns
+        recovering sunken treasure off the coast of Hispaniola, George Churchill who commanded the
+        frigate "Falcon" and piracy. 1794. Navigational profiles-sailing directions from the Isle of
+        Wight to the Anamba Islands...written by John Cottrell, naval officer. Sept. 6, 1803: Letter
+        from Horatio Nelson, deals with desertion of seamen and marines. Dec. 24, 1812-Apr. 17,
+        1818: Volume of copies or drafts of letters from and to the ship brokers, McNeill &amp; Co.
+        Jan. 1-Dec. 28, 1816: Account book of a merchant who lists costs of various voyages to
+        Jamaica, Hamburg and Lisbon. Oct. 7, 1820-June 12, 1821: Log of Proceedings on board the
+        "Albion" of London. Apr. 21, 1866: Certificate of the arrival and departure of the "Barca"
+        Louisa Cook.</p>
+      <p> Note on Indexing Term - "Religion": n.d. G.R. Steele, Notes on the history of the
+        Covenanters in Scotland and on the life of David Jamison Shaw. n.d. Thai book of Buddhist
+        religious literature. n.d. (folio). The Perfection of Wisdom in Eight Thousand Verses
+        ('phags pa shes rab kyi pha rol du phyin pa brgyad stong pa).</p>
+      <p> Note on Indexing Term - "Science": Of interest: 1795 astrophysical text entitled, Elementa
+        Philosophie Universe written by professor Thoma Garcia de Zuniga. March 24, 1820 letter from
+        astronomer Jean Baptiste Joseph Delambre to mathematician Joseph Nicolas Nicollet. 1845 copy
+        of a text in Turkish which deals with medical and pharmaceutical chemistry. Undated German
+        text written by Indiana University botany professor Frank Marion Andrews entitled
+        Zoologie.</p>
+      <p> Note on Indexing Term - "Travel": Of interest is a 1834-1841 journal and memorandum book
+        of the plantation "Thomas" in British Guiana and travels in Great Britain. Includes
+        descriptions of several trips to the United Kingdom written by plantation owner R.G. Butts.
+        Also, an 1834-1835 journal of an European tour written by Henry Bertie and an anonymous 1849
+        diary of boat and overland trips in the U.S. and Canada.</p>
+      <p> Note on Indexing Terms - "West (U.S.)" and "Americana": Of particular interest is a diary
+        of boat and overland trips in the U.S. and Canada dated Jan. 1- Nov. 14, 1849.</p>
+      <p> Note on Indexing Term - "World War, 1914-1918": Of particular interest is a 1914- 1916
+        diary of Philip Sass, soldier and businessman. Written in German, this diary gives a day to
+        day account of a German soldier fighting Russian troops.</p>
+      <p> Note on Indexing Term - "World War, 1939-1945": Of interest is a Jan. 24, 1940 letter from
+        Margaret Steggall to Mr. and Mrs. Robert Burke of Bloomington, Indiana which contains a
+        description of London in wartime.</p>
+    </scopecontent>
+    <relatedmaterial id="aspace_33cb6fc9efd91366d9783042afe4840d">
+      <head>Related Material</head>
+      <p>See Lafayette mss. and Gordimer mss., also located at the Lilly Library, Indiana
+        University, Bloomington, Indiana.</p>
+    </relatedmaterial>
+    <acqinfo id="aspace_874f1857842a75159a5e5861a10e62e7">
+      <head>Acquisition Information</head>
+      <p>See individual item descriptions for acquisition information.</p>
+    </acqinfo>
+    <userestrict id="aspace_2e438ff11f3e255f3e4183ddc289f831">
+      <head>Usage Restrictions</head>
+      <p>Photography and digitization may be restricted for some collections. Copyright restrictions
+        may apply. Before publishing, researchers are responsible for securing permission from all
+        applicable rights holders, then filling out the <extref
+          xlink:href="https://libraries.indiana.edu/lilly-library/permission-to-publish"
+          xlink:show="new" xlink:actuate="onrequest">Permission to Publish form.</extref></p>
+    </userestrict>
+    <prefercite id="aspace_59ba906cfa03715c76315e25028e3b9e">
+      <head>Preferred Citation</head>
+      <p>[Item], Miscellaneous mss., Lilly Library, Indiana University, Bloomington, Indiana.</p>
+    </prefercite>
+    <controlaccess>
+      <subject source="lcsh">Law</subject>
+      <subject source="lcsh">Medicine</subject>
+      <subject source="lcsh">Music</subject>
+      <subject source="lcsh">Voyages and travels</subject>
+      <subject source="lcsh">Religion</subject>
+      <subject source="lcsh">Science</subject>
+      <subject source="lcsh">Travel</subject>
+      <subject source="lcsh">West (U.S.)</subject>
+      <subject source="lcsh">Americana</subject>
+      <subject source="lcsh">World War, 1914-1918</subject>
+      <subject source="lcsh">World War, 1939-1945</subject>
+      <geogname authfilenumber="sh85051319" source="lcsh">France -- History -- Revolution,
+        1789-1799</geogname>
+      <subject source="lcsh">Cuneiform tablets</subject>
+      <persname source="lcnaf">Darwin, Charles, 1809-1882</persname>
+      <persname source="lcnaf">Barnum, P. T. (Phineas Taylor), 1810-1891</persname>
+    </controlaccess>
+    <dsc>
+      <c01 id="aspace_ce9ff612853c02e0e70f9bfaca11842a" level="series">
+        <did>
+          <unittitle>Miscellaneous mss.</unittitle>
+        </did>
+        <c02 id="aspace_f677a78c93f908f4de71c1c41f3d9c2b" level="file">
+          <did>
+            <unittitle>Babylonian cuneiform terra cotta cone from ruins of a temple wall of Ur of
+              the Chaldees.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">1 cone. 12 x
+                4 cm.</extent></physdesc>
+            <unitdate datechar="creation" era="bce" normal="2060/2060">2060 BCE -</unitdate>
+            <container id="aspace_fdbd46f05356f7b9660951b4e6b5f4f4" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_57c4c35a783e42cc789d502bb4bb81ca">
+            <head>Scope and Contents</head>
+            <list type="ordered">
+              <item>"The accompanying terra cotta cone was found several years ago by native Arabs
+                in one of the ruin mounds of Ur of the Chaldees, the birthplace of the Biblical
+                Abraham, now called Mugheir, on the lower Euphrates in Southern Babylonia. It was
+                built into a temple wall with several other similar cones, to serve the purpose of
+                the modern corner stone, with the hope that one of them might survive to tell future
+                generations who built the temple. It bears a fine cuneiform inscription of twenty
+                lines in two columns in the Sumerian language which was used in Babylonian before
+                the Semitic Babylonian, and it comes from Libit-Ishtar, a prominent Babylonian king
+                whose date has been fixed at 2060 B.C., just before the time of Abraham. This
+                inscription is probably the best example yet discovered of the writing of the exact
+                age of Abraham and in his own country. It is also of historical interest, for it
+                mentions several of the early cities of the book of Genesis, the existence of which
+                was once doubted. Its translation reads: 'The divine Libit-Ishtar, the humble
+                shepherd of Nippur, the faithful husbandman of Nippur, who does not change the face
+                of Eirdu, a king befitting Erech, the king of Isin, the king of Sumer and Akkad
+                (North and South Babylonia) who captivated the heart of the goddess Ininni (Ishtar)
+                am I. When the justice in Sumer and Akkad he had established, the temple of justice
+                he built.'" Edgar James Banks, Field director of the Babylonian expedition from the
+                University of Chicago, 1903-1906, to Carroll A. Wilson, n.d.</item>
+              <item>Lipit-Ishtar, king of the city/state of Isin, reigned from ca. 1934-1923 BCE
+                according to Gordon D. Young, Purdue University, 11 July 1975.</item>
+              <item>Cone is designated as Lipit-Ishtar 2: 21-line cone in W. W. Hallo, "Royal
+                Inscriptions of the Early Old Babylonian Period: a Bibliography," <title
+                  render="italic">Bibliiotheca Orientalis</title> XVIII No. 1/2 (Jan.-Mar., 1961),
+                4-14 (Z3001 .B584).</item>
+              <item>Cone is placed in its historical context by Edmund Gordon in "Lipit-Ishtar of
+                Isin," <title render="italic">Dudley Peter Allen Memorial Art Museum,
+                  Bulletin,</title> (Oberlin College, Ohio) 14 (1956) 16-27.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9eb24f9cdac9d8635a686d075d65c1c1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. David A. Randall, Bloomington, Indiana. <date normal="1965">1965.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d5e05ce8cf35fe05056e8547f8a5ddbd" level="file">
+          <did>
+            <unittitle>Babylonian cuneiform tablet of Sumerian text from the third dynasty of Ur,
+              2100-2000 BCE, having incised on both sides material relating to commerce in
+              Ur.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">1 tablet. 5 x
+                4.5 cm.</extent></physdesc>
+            <unitdate calendar="gregorian" datechar="creation" era="bce" normal="2100/2100"
+              >2100-2000 BCE -</unitdate>
+            <container id="aspace_280b9c3b6a2d5a3d041cc0326e13a261" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_08e5ca6dc30abe984034868bd2c293c0">
+            <head>Scope and Contents</head>
+            <list type="ordered">
+              <item>Date of tablet has been placed in the nine year reign of Amar-suena (ca.
+                2047-2039 BCE) according to Gordon D. Young, Purdue University, 11 July 1975.</item>
+              <item>Drawing of tablet, transcription and English translation by Stephen D. Simmons
+                published in <title render="italic">Journal of Cuneiform Studies,</title> XVII: 32
+                (April 1936) (PJ3102 .J86).</item>
+              <item>Transcription and English translation by Edmond Sollberger published in
+                Sollberger, <title render="italic">Business and Administrative Correspondence Under
+                  the Kings of Ur,</title> Locust Valley, N.Y., J. J. Augustin publisher, 1966, page
+                20 (Texts from Cuneiform Studies, Vol. 1) (PJ4075 .S68).</item>
+              <item>The top three lines tell of a religious festival for which the sheep and grain
+                are needed. Below that is given the name of the person to whom they are to be sent.
+                The name of the writer of the letter is not given on the tablet. Originally this
+                tablet would have been in a clay envelope on which the seal of the writer would have
+                appeared. This would have been sufficient to identify him. In writing on one of
+                these tablets it was grasped between thumb and first finger at the top of the sides.
+                The indentations here can still be felt on this tablet. This tablet has been
+                partially baked. (Information from Ferris J. Stephens, Curator of Babylonian and
+                Assyrian Clay Tablets, Yale University Library, 1958, January 23.)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_97b1652e8af6be4d0bdb138cc65b0604">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bodley Book Shop, New York (Catalog 103, item no. 42). <date normal="1948"
+                >1948.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_aad7ca9251ee9eae79d8e1ddcd414361" level="file">
+          <did>
+            <unittitle>Sumerian administrative clay tablet</unittitle>
+            <unitdate datechar="creation" normal="1990/1999" type="inclusive">Third Dynasty of Ur,
+              Umma, ca. 2049-2044 BCE</unitdate>
+            <physdesc audience="internal" id="aspace_763f667e470d9d3d64b369bd46667168">1 fired clay
+              tablet; 38 x 37 mm.</physdesc>
+            <container id="aspace_0919f47cd1a3f3faaa6f2c601da88803" label="Mixed Materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent audience="internal" id="aspace_330382c4ab90435d6707bb4f6e91e9ec">
+            <head>Scope and Contents</head>
+            <list audience="internal" type="ordered">
+              <item>Sumerian administrative tablet of baked clay, inscribed on both sides in
+                cuneiform characters, recording the receipt of a barley delivery. With the
+                impression of a Sumerian administrative seal. Originally from the collection of
+                Eleanor Lowenstein</item>
+              <item>The text reads that 1 royal gur of barley was received from a man named Ir in
+                the Month RI (the fifth month in the calendar of the city of Umma), the year after
+                the city of Urbillum was destroyed. This would be either 2049 or 2044 B.C. as this
+                year formula was used for both these in the reigns of King Shugi and King Amar-Suen
+                respectively. The seal impression reads "Ur-e-. son of Lu-Sharake," meaning "Man of
+                Shara," which was the city god of Umma</item>
+            </list>
+          </scopecontent>
+          <acqinfo audience="internal" id="aspace_0c60c845ca5d76a74bafd7e303903e15">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase: 2005</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9bf248e8cd1191ee94411c30f3335db1" level="file">
+          <did>
+            <unittitle><persname>Nevers, Louis de Gonzague, duc de, 1539-1595.</persname> To Clemens
+              VIII, pope. Concerns Henri IV's struggle to establish himself as King of France and
+              his conversion to Catholicism.</unittitle>
+            <unitdate datechar="creation" normal="1594-01-14/1594-01-14" type="inclusive">1594,
+              January 14 -</unitdate>
+            <physdesc id="aspace_966ae511092a72304c8accee4913a7e8">Autograph document 76 p. 21 x 31
+              cm.</physdesc>
+            <container id="aspace_9ce05975c50701226f6460841f7d3ba9" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_fb0cfe23e2d812336da4a19c662b5679">
+            <head>Scope and Contents</head>
+            <list type="ordered">
+              <item>Accompanied by two letters from Henri IV to the Pope; the duc de Nevers'
+                credentials; the duc de Nevers' memorandum formally requesting the papal blessing; a
+                note requesting an audience with the Pope; and a note from the Pope to the duc de
+                Nevers.</item>
+              <item>Italian</item>
+              <item>Bound in Levant, lettered in gold and tooled in blind. Monogram on cover.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6f05a9edac8f739697462634f8d54426">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. William Salloch, Pines Bridge Road, Ossining, New York, 10562. <date
+                normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ecd665ae4a3a03ef111277b4e2302e66" level="file">
+          <did>
+            <unittitle>Rosarium Philosophicum.</unittitle>
+            <unitdate datechar="creation" normal="1600/1625" type="inclusive">1600-1625?
+              -</unitdate>
+            <physdesc id="aspace_56085a4dfe86525028c9d9ad7a771e81">Autograph document 23 p. 31 x 23
+              cm.</physdesc>
+            <container id="aspace_56c4f420256bbd0103c1d9fe4585221f" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_197c91ee34a5a1da2611cd15fb3c1e2f">
+            <head>Scope and Contents</head>
+            <list type="ordered">
+              <item>Latin</item>
+              <item>Written in Italy?</item>
+              <item>Symbolical drawings in red chalk with inscriptions in black ink on paper</item>
+              <item>Excerpts of the illustrated portions of Rosarium Philosophicum, sometimes
+                ascribed to Arnaldus de Villanova</item>
+              <item>Bound in modern boards of red and gold</item>
+              <item>Published as <title render="italic">Rosarium Philosophicum Secunda pars
+                  Alchimiae. De alchimia opuscula complura veterum philosophorum,</title> etc. 2
+                pts. In officina C. Iacobi: Frankfort, 1550. See Goff, <title render="italic"
+                  >Incunabula in American Libraries, Third Census.</title> Bibliographical Society
+                of America, New York, 1964 (Lilly Z240 .G61 copy 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4b9a6ec60dfed873f3d26b32af3f263a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. Harper lot 13221. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_17cba74e513bfe3185400fb6dc2141d6" level="file">
+          <did>
+            <unittitle><persname>Pattricke, Fr., fl. 1605.</persname> Grayes Inne. To Samuel Borne.
+              An account of the Gunpowder Plot and the seizure of Guy Fawkes.</unittitle>
+            <unitdate datechar="creation" normal="1605-11-11/1605-11-11" type="inclusive">1605,
+              November 11 -</unitdate>
+            <physdesc id="aspace_1e8c20f6fbc555684114b12c8f76b0ea">Autograph letter signed 1 p. 30
+              cm.</physdesc>
+            <container id="aspace_8bdedc84f8866836e248c79f1c79eea6" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_9542bda50ec05f1e463cb4eb4cade0e5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by a copy of warning letter to Lord Monteagle. Autograph document 1
+                p. 15 cm.</item>
+              <item>Includes transcription</item>
+              <item>This is apparently the only private letter containing a detailed contemporary
+                account of the Gunpowder Plot. The fact that the letter is dated from Gray's Inn
+                indicates that the writer had legal connections, and this may account for his inside
+                knowledge of the affair less than a week after the event.</item>
+              <item>The enclosed copy - also in Pattricke's hand - of the warning letter to
+                Monteagle contains a few verbal variants from the original. At the foot is
+                Pattricke's note that it was "Delivered to my Lorde of Mountegles page inclosed in a
+                letter of his" and a list of the gunpowder and "other instruments" found in the
+                cellar with Guy Fawkes.</item>
+              <item>From the Catesby collection</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f044c078b9735ecfb3bff825483c1377">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Alan G. Thomas, 7a Wimborne Road, Bournemouth, Hampshire, England. <date
+                normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3e2e4a942a12661a12af944927a3d814" level="file">
+          <did>
+            <unittitle>Morgen-wecker: aen de oude ende ghetrouwe Batavieren. Met een remedie teghen
+              haere slaep-sieckte...</unittitle>
+            <unitdate datechar="creation" normal="1620/1620" type="inclusive">1620 -</unitdate>
+            <physdesc id="aspace_80b8202f1951868aeb6e2623c1ec1f58">Bound document 14 p. 20
+              cm.</physdesc>
+            <container id="aspace_d97c6e449a723042abc63b13541be7d4" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_2d5deb889eb1cb096d4955651f1d338d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Probably by Henricus Slatius. Knuttel, Willem Pieter Cornelis. Catalogus van de
+                pamfletten-verzameling berustende in de Koninklijke bibliotheek ...'s Gravenhage,
+                1889. vol. 1, pt. 1, 1486-1620, p. 590, no. 3087.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c797f07eb5b667ec89e26c93f0df5cde">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. International U. Booksellers, Ltd., 94 Gower St., London, England. From
+              the library of Gustaaf Johannes Renier, professor of Dutch history and institutions,
+              University of London. <date normal="1952">1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_02a4363dcbb85c795a24374ac916a7f1" level="file">
+          <did>
+            <unittitle><persname>Pembroke, Philip Herbert, 4th earl of, 1584-1650,
+                parliamentarian.</persname> Hampton Court. To Rrobert Sidney earl of Leicester.
+              Refers to the coronation of Charles I in February and the meeting of the second
+              parliament.</unittitle>
+            <unitdate datechar="creation" normal="1625-12-24/1625-12-24" type="inclusive">2625,
+              December 24 -</unitdate>
+            <physdesc id="aspace_c89f0f147e7cbd500f4e969cad5cedfc">Typescript 2 p. 28 cm.</physdesc>
+            <container id="aspace_a65abfe710aa512e5c3a3d4573f35f78" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_fe362ba166ac3a00f3421ee6387dab11">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Only typescript (not original) is present</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c147d63c5ddcbe6eb554e189b3a3a634">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_62cac8835b3574c4e6b0d90953322b26" level="file">
+          <did>
+            <unittitle>Annotations in Czech, formerly used as an endpaper for a book.</unittitle>
+            <unitdate datechar="creation" normal="1636-04-03/1636-04-03" type="inclusive">3 April
+              1636 -</unitdate>
+            <physdesc id="aspace_a3304cdb82e13349a9887873f15c26e9">Autograph document 2 p. 22.5
+              cm.</physdesc>
+            <container id="aspace_b0a24d0be695f6d9ce68784e42d394fd" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_100c5ca2811cecefcbd5326f5d004814">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In ink</item>
+              <item>With corrections in pencil, and a few other words in pencil</item>
+              <item>Removed from Georg Weis, <title render="italic">Gloria Universitatis
+                  Carolo-Ferdinandeae Pragensis...</title> 1672 (Lilly LF1462.5 .W426) in
+                1980</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_40dba03f83ff82c93880004cc130eaa7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1980">1980.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c84ca86c4499a9847a4e4307914fb159" level="file">
+          <did>
+            <unittitle>Grant to Sir Francis Kinaston Knight and others in the eleventh year of the
+              Reign of King Charles for the establishment of the Musaeum Minervae.</unittitle>
+            <unitdate datechar="creation" normal="1636-06-26/1636-06-26" type="inclusive">1636, June
+              26 -</unitdate>
+            <physdesc id="aspace_789ce067bc88ed2025d56ea5a9fc6b06">Autograph document 13 p. 18
+              cm.</physdesc>
+            <container id="aspace_25973630b053321c06e4171ccf9955f2" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_6589d3377b054e791ea52cac07d25d67">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>The above is a translation from the Patent kept in the Rolls Chapel by C.
+                Richardson Junior, May 1812</item>
+              <item>Bound in Kynaston, <title render="italic">The Constitutions of the Mvsaevm
+                  Minervae.</title> London. Printed by T. P. for Thomas Spencer, 1636 (Lilly DAE681
+                .K99 C75).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cc3341ad20c74e8611f6e9e05b9d023a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1974">1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_428aa39472b8288f7ef6c37d3ce987fd" level="file">
+          <did>
+            <unittitle><title render="italic">Relacon of Count Maurice his Proceedings &amp;c: in
+                Brasill.</title></unittitle>
+            <unitdate datechar="creation" normal="1638-06-30/1638-06-30" type="inclusive">1638, June
+              30 -</unitdate>
+            <physdesc id="aspace_11cb20fe2b780927fd194daf753d6517">Autograph document 2 p. 31
+              cm.</physdesc>
+            <container id="aspace_be07a4d5a007f6d9e2dad297e68d2c04" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_ed5608e01bd319d0d6746d14ea715a64">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Watermark: grape with decorative base</item>
+              <item>Pages numbered 77 and 79 in pencil</item>
+              <item>Title on adjunct pages</item>
+              <item>Count John Maurice of Nassau-Siegen was the Dutch governor, 1636-1644</item>
+              <item>Based on information from Manuel Perez Aleman, commander of the Portuguese
+                merchant ship El Sacramento of an event occurring Sunday 28th April</item>
+              <item>Reports the nature of the siege of Bahia and Baya de Todos los Sanctos and the
+                volume of chests of sugar on board the merchant ships</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_60486040a2882ec67d8381549be9e3a0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Hofmann &amp; Freeman, Kent, England. <date normal="1975">1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a5c667a96119f680d9fd08383f92e31f" level="file">
+          <did>
+            <unittitle>Gr. Brit. Parliament. House of Commons. Journals.</unittitle>
+            <unitdate datechar="creation" normal="1640-04-13/1681-03-28" type="inclusive">1640,
+              April 13-1681, March 28 -</unitdate>
+            <physdesc id="aspace_3048abcbb0b4bce36a4cd8b7768e22f4">Autograph documents (9 volumes)
+              31 x 20 cm.</physdesc>
+            <container id="aspace_3e208533bc04cb3ee0fba6448e1d4b66" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_cbdc09ed03cb989612de049721e544f2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Contemporary copies</item>
+              <item>Volumes bound in old reversed calf in worn, torn condition</item>
+              <item>Each volume bears the bookplate, according to the dealer, of James Butler, Earle
+                of Ormonde, 1610-1688, lord lieutenant of Ireland.</item>
+              <item>Volumes cover the years 1640-1641, 1653-1659, and 1661-1681 as follows: 1) 1640,
+                Apr. 13-1641, Jan. 3. 589 numbered pages. Index of 24 pages. Spine reads: Commons
+                Journal 1640 1641; 2) 1641, Jan. 4-1642, Oct. 25. 621 numbered pages. Index of 24
+                pages. Spine reads: Commons Journal 1641 1641; 3) 1653, July 4-1659, Mar. 6. 606
+                numbered pages. Index of 22 pages. Ink in faded condition; 4) 1660, Apr. 25-1660,
+                Dec. 29. 770 numbered pages. Index of 24 pages. Spine label partially torn off; 5)
+                1661, May 8-1666, Oct. 10. 702 numbered pages. Index of 24 pages. Spine reads:
+                Commons Journal 1661 1666. Bound with ms fragment on spine inside front cover; 6)
+                1667, Oct. 14-1673, Oct. 20. 580 numbered pages. Index of 23 pages. Spine reads:
+                Commons Journal 1667 1673; 7_ 1673, Oct. 1-1678, May 4. 643 numbered pages. Index of
+                24 pages. Spine reads: Commons Journal 1673 1678; 8) 1678, May 6-1678, Dec. 30. 432
+                numbered pages. Index of 24 pages. Spine reads: Commons Journal 1678 1678; 9)
+                1678/9, Mar. 6-1681, Mar. 28. 583 numbered pages. Index of 24 pages. Spine reads:
+                Commons Journal 1679 1681.</item>
+              <item>Published in Gt. Brit. Parliament. House of Commons. <title render="italic"
+                  >Journals.</title> Vols. 1-32, 1547-1770. London, 1742- (Lilly J301 .J86). Vols.
+                2-9.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3888a845879bf9d9572b173a62eb1446">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Antiquarian Books/Celtic Studies, 15 South Frederick Street, Dublin,
+              Ireland. <date normal="1975">1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bff521eec1ec92dc437da45b40d0f7e3" level="file">
+          <did>
+            <unittitle><persname>Germano, Giovanni, Neapolitan priest.</persname> La Culla d'Oro.
+              Tragicomedia...sopra la nascita del...Principe Toscana primogenito del...Gra Duca
+              Ferdo II. Naples.</unittitle>
+            <unitdate datechar="creation" normal="1642-10-15/1642-10-15" type="inclusive">1642,
+              October 15 -</unitdate>
+            <physdesc id="aspace_6553c3ebb60ed7dc91b503cb8ba98e20">Autograph document signed 251 p.
+              20 cm.</physdesc>
+            <container id="aspace_961ff91b32c88f433b31983736c14f45" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_dc3f61c77d1f534abf5197bb730a25ad">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Italian</item>
+              <item>Title page written and decorated in gold with a large miniature in blue, white
+                and gold showing the newborn Prince of Tuscany lying on a bed within the signs of
+                the zodiac.</item>
+              <item>Headings of the prefatory pages in gold</item>
+              <item>Initial letter of each scene and the Choro in gold</item>
+              <item>Dedication to the grand duke of Tuscany, Frederick II, dated October 15,
+                1642</item>
+              <item>Bound in contemporary vellum, tooled in gold with the coat of arms of the Medici
+                family on both covers</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a84da33fafb9884e5b79fdcfbd6a9e88">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b9dc39d38c3f78e7f164285d5ad786c5" level="file">
+          <did>
+            <unittitle><persname>Pembroke, Philip Herbert, 4th earl of, 1584-1650,
+                parliamentarian.</persname> Whitehall. To John Moore. With the next messenger should
+              hear about matters of great importance.</unittitle>
+            <unitdate datechar="creation" normal="1647-08-05/1647-08-05" type="inclusive">1647,
+              August 5 -</unitdate>
+            <physdesc id="aspace_870c7f8a1f27a0799c9fd2b1aa43e2be">Typescript 2 p. 28 cm.</physdesc>
+            <container id="aspace_88e94a5ca7b2a2027529ae31179c6aa6" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_d129c8704113a82a3eb1ec608edb71f6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Only typescript (not original) is present</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_aaf907b0b35dbbe5502478fd7452adf4">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bbe8feb348d35a893006d977489d3592" level="file">
+          <did>
+            <unittitle>Pietro Bernardin et Antoni Aluigi fratelli Colombi discendenti per retta
+              linea da Nicol Colombi, chi fa fratelli del Padre di quel gran Christofforo scopritor
+              del nuous Monde desiderosi d'esser creati, et dichiarati cittadini
+              Piacentini...</unittitle>
+            <unitdate datechar="creation" normal="1647/1647" type="inclusive">1647 -</unitdate>
+            <physdesc id="aspace_69d52a718328498f5f3c4aaa367624c9">Autograph document signed 7
+              leaves 30 cm.</physdesc>
+            <container id="aspace_2b4770facc4ef8924a9abbdc4d8d09fc" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_a57b2d61c53b58258b8a5942685c8675">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Petition written in two or more hands</item>
+              <item>Subsequent information dated 1682 and 1703</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4f10ffc1635a70d8b2c06ee8361fec7a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_93355b6891f2ea4a7c7262616b11f727" level="file">
+          <did>
+            <unittitle>Winslow, Edward, et al., 1595-1655, governor of Plymouth Colony. Case of Sir
+              Roger Twysden concerning an assessment.</unittitle>
+            <unitdate datechar="creation" normal="1651-10-17/1651-10-17" type="inclusive">1651,
+              October 17 -</unitdate>
+            <physdesc id="aspace_000f760af002a83f713205b44a84b572">Autograph document signed 1 p. 30
+              cm.</physdesc>
+            <container id="aspace_6cd45f05d84bf3c805e90af6124cf729" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_9b1a6da2c35fadebeb887f5845295deb">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by an order from the commissioners for advancement of money to Sir
+                Roger Twysden, dated Sept. 24, 1651. Autograph document signed 1 p. 30 cm.</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d155c2f4737170a4590a47073bc96c95">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9c92a41a75443103cb218ec2b999c3dc" level="file">
+          <did>
+            <unittitle><persname>Lawson, Sir John, -1665, admiral.</persname> Naval affairs, &amp;
+              the Dutch war in K. Charles ye 2d's reign &amp; the time of Oliver.</unittitle>
+            <unitdate datechar="creation" normal="1652-11-16/1653-09-20" type="inclusive">1651,
+              November 16-1653, September 20 -</unitdate>
+            <physdesc id="aspace_1fa15a41ba26d36a703cf70bb896b87a">Document signed 31 p. 31
+              cm.</physdesc>
+            <container id="aspace_45bef281349e87fe5d877b0ab93df157" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_3c01063f4be75f5b3cab462cd4074ff7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Title in hand of Sir Henry Coverntry according to dealer. "Sr John Lawson in ye
+                Fairfax Journall part off the Dutch warr" in Lawson's hand on the cover page.</item>
+              <item>Written in a scribal hand with three additions and revisions in Lawson's hand on
+                pages 77, 78, 93. Folio is paginated in pencil, 69-107. Reported as disbound from
+                Philipps ms 4895.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_78163daf82fdef2a53c578e01a231659">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Hofmann &amp; Freeman Ltd., 50 London Road, Sevenoaks, Kent. <date
+                normal="1976">1976.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b35ec69c3f42b1a3c27706d99dc7f92b" level="file">
+          <did>
+            <unittitle>Hollandts venezoen in Engelandt gebackken en geopent voor de liefhebbers
+              van't vaderlant.</unittitle>
+            <unitdate datechar="creation" normal="1672/1672" type="inclusive">1672 -</unitdate>
+            <physdesc id="aspace_2770cf8fdfa38bc3c7eaa4d17aa39aec">Document 13 p. 20 cm.</physdesc>
+            <container id="aspace_dddc88c09f1fb42ae495cf0f013e3fda" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_553c87ce6a43a297f0117e0827f80be1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Printed version listed in Knuttel, Willem Pieter Cornelis. Catalogus van de
+                pamfletten-verzameling berustende in de Koninklijke bibliotheek...'s Gravenhage,
+                1895. Vol. 2, pt. 2, 1668-1688, p. 135-136, nol 10606.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ec709455a2d67e64152d2cf501b2af84">
+            <head>Immediate Source of Acquisition</head>
+            <p><date normal="1956">1956</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_239d8de427b19d61b4aeb1d8380fead3" level="file">
+          <did>
+            <unittitle>Letter from a person of quality</unittitle>
+            <unitdate datechar="creation" normal="1675/1675">1675</unitdate>
+            <container id="aspace_57c307160f6bafc6835eabb9cd6771a1" label="Mixed Materials"
+              type="Bound">Bound</container>
+          </did>
+        </c02>
+        <c02 id="aspace_0307ce20276b44f75b7fd9be016eda90" level="file">
+          <did>
+            <unittitle><persname>Cerri, Urbano, -1679, author.</persname> Stato della Religione
+              Cattolica in tutto il Mondo. Per la santita di Nro Signore Innocentio XI.</unittitle>
+            <unitdate datechar="creation" normal="1677/1677" type="inclusive">1677 -</unitdate>
+            <physdesc id="aspace_4f053ce0879679db81350bf683ce2452">Autograph document 123 p. 31
+              cm.</physdesc>
+            <container id="aspace_97327e69943cd10fc8a38612303cedd9" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_c0644d5a47ba5e82a31ee60f24fc4d49">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in contemporary vellum</item>
+              <item>In Italian</item>
+              <item>In ink</item>
+              <item>The title page, table of contents, and the first five and one-third pages of the
+                text are written in one hand; the remainder of the manuscript is in another hand and
+                an index at the end of the text of nine and one-half pages, corrected with pasted
+                strips over page numbers (contemporary).</item>
+              <item>It is arranged geographically.</item>
+              <item>Urbano Cerri was named secretary of the congregation of <title render="italic"
+                  >Propaganda Fide</title> in 1675 and is so identified on the title.</item>
+              <item>Sir Richard Steele, in <title render="italic">An account of the State of the
+                  Roman Catholic religion...</title> London, Printed for rJ. Roberts, 1715 (Lilly
+                BX1361 .C4), includes the dedication to Clement XI presumed to be by Bishop Benjamin
+                Hoadly. Steele's edition was made from a copy in the library at St. Gallen and sent
+                to England.</item>
+              <item>In 1716 a French edition was published in Amsterdam. Christian Gottlieb Jocher,
+                  <title render="italic">Allegemeines Gelehrten-Lexicon...</title> Hildesheim, 1960,
+                supplement II, col. 220 (Lilly Z1010 .J63 v.6).</item>
+              <item>The translation was done by Michael de la Roche, and the dedication to the pope
+                done by another who was better versed in ecclesiastical history than Sir Richard
+                Steele. <title render="italic">Biographia Brittanica.</title> London, 1778-1793, VI,
+                part 1, p. 3830 (Lilly DA28 .B7 v.8).</item>
+              <item>According to Robert Streit there are only three manuscripts of this text: one in
+                Italian at Munich, one in Italian at Rome, and one in Italian and Spanish at
+                Madrid.</item>
+              <item>The provenance of the Lilly Library manuscript is also mostly English. It
+                carries the inscription "Payne" (18th cent.) in the upper right-hand corner on the
+                inside of the front cover; has the armorial engraved bookplate of the bibliophile
+                and Hellenic scholar Frederick North, 5th earl of Guilford (1766-1827), founder of
+                the Ionian University at Corfu; and is more recently from the famous collections of
+                Sir Thomas Phillips (Phillips ms. 7826). It was sold by Sotheby in 1913 and
+                purchased by the Lilly Library from Lathrop C. Harper, 8 W. 40th Street, New York,
+                New York.</item>
+              <item>It also bears on the title page the stamp (19th century?): "Ex Bibl. Ios. Ren.
+                Card. Imperialis," whose identity it was not possible to trace.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ce8dd4a18c4a9db57159f42a7e709bc8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Lathrop C. Harper, 8 West 40th Street, New York, New York. <date
+                normal="1967">1967</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c4bfea001f631fac334d0e6bebf94e20" level="file">
+          <did>
+            <unittitle><persname>Costard, Mme. Marie (Lambert).</persname> Marie Lambert, veuve de
+              Jacques Costard (or Costart?) prolonge le bail de Sebastien Campion au nom de l'évêque
+              de Berytte.</unittitle>
+            <unitdate datechar="creation" normal="1678-06-30/1678-06-30" type="inclusive">1678, June
+              30 -</unitdate>
+            <physdesc id="aspace_88cf3fcc90e3793eb40b246bc2aa704e">Document signed 3 p. 25
+              cm.</physdesc>
+            <container id="aspace_356760ad212f184324a09e05a9f86a39" label="box" type="box"
+              >1</container>
+          </did>
+          <acqinfo id="aspace_c3e9bc3b0e48635532a9a0ef45af2337">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Daniel Smith. <date normal="1934">1934.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7e538a743778295abdda51d6d80b2360" level="file">
+          <did>
+            <unittitle>Gt. Brit. Parliament. House of Commons. "A true coppy of the Journall Booke
+              of the House of Commons for the Sessions of Parliament begun at Westminster ye 21th
+              day of October 1678 and continued to ye 30th day of December..."</unittitle>
+            <unitdate datechar="creation" normal="1678-10-21/1678-12-30" type="inclusive">1678,
+              October 21-December 30 -</unitdate>
+            <physdesc id="aspace_48002bc7384c90991ec0fc0af4611b77">Autograph document 172 leaves 21
+              x 32 cm.</physdesc>
+            <container id="aspace_3ff846cd0cdf3949a869baa181ed7afc" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_f10d435c59b3e3abf9842d07a9747be6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. James B. McCloskey, 6127 N. Charles Street, Baltimore, Maryland. 21212.
+                <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_edd2b8b538137554aa1a3fb72db57f7e" level="file">
+          <did>
+            <unittitle><persname>Hinton, Sir John, 1603?-1682, physician.</persname> Memoires by Sir
+              John Hinton, Physitian [sic] in ordinary to his Majesties Person.</unittitle>
+            <unitdate datechar="creation" normal="1679/1679" type="inclusive">1679 -</unitdate>
+            <physdesc id="aspace_729f5e5928c196ebc56f9df20c94550c">Autograph document signed 44
+              leaves 12.5 x 9 cm.</physdesc>
+            <container id="aspace_bd5be9f2db7e0e1770b96ad134f26273" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_8c13ad1e96038cbb463f2987d0d2f164">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Phillips mss. 4267</item>
+              <item>Leaves lined in red ink on recto and verso</item>
+              <item>Text written in printed style on recto</item>
+              <item>Bound in contemporary English black leather</item>
+              <item>Full-gilt spine</item>
+              <item>Covers decorated in gold with drawer-handle and filigree tools, extra</item>
+              <item>Two silver clasps, gilt edges, marbled endpapers</item>
+              <item>Spine and edges worn</item>
+              <item>Published in London in 1814 of which one hundred copies were printed</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_18bbf2731039160e0331d78cbf85ea63">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Scribners Bookstore, 597 Fifth Avenue, New York, 10017. <date
+                normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0285477712e6a2e435d1c7d3611d59ca" level="file">
+          <did>
+            <unittitle><persname>Lyndh, Sir Thomas, -1684, governor of Jamaica.</persname> Jamaica.
+              To Charles II, King of Great Britain. Concerns recovering sunken treasure off the
+              coast of Hispaniola, George Churchill who commanded the frigate Falcon, and
+              piracy.</unittitle>
+            <unitdate datechar="creation" normal="1683-08-15/1683-08-15" type="inclusive">1683,
+              August 15 -</unitdate>
+            <physdesc id="aspace_cdba410f19ea9f58c6eafbbf3d0c9e6c">Autograph letter signed 3 p. 36
+              cm.</physdesc>
+            <container id="aspace_25560a81acc1bdddea3683113ea6f03f" label="box" type="box"
+              >1</container>
+          </did>
+          <acqinfo id="aspace_5e3770707b20b198bdd1305dcfaaf850">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased by Lathrop C. Harper, 8 West 40th Street, New York, New York, 10018. Harper
+              Lot 21101. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6d12a3a1221001d7454fe208db0bcef8" level="file">
+          <did>
+            <unittitle><persname>La Bédoyère...Huchet, compte de, attorney general.</persname> To
+              "le procureur du roy." Feugères, France. Concerns the revocation of the Edict of
+              Nantes.</unittitle>
+            <unitdate datechar="creation" normal="1685-10-27/1685-10-27" type="inclusive">1685,
+              October 27 -</unitdate>
+            <physdesc id="aspace_cf5b259b686a0bb886aabf5cbe9e774d">Autograph letter signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_1200883f11c2678b5185914e25a1364b" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_eb8a27d194fd38bea02bedd5db4253ac">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In French</item>
+              <item>Sender's name determined from dealer's note</item>
+              <item>Also present is statement concerning the published revocation, Nov. 1685.
+                Autograph document 1 p. 21 cm.</item>
+              <item>Removed from <title render="italic">Edit du roy portant revocations de celuy de
+                  Nantes...</title> Vennes: chez Moricet &amp; la Veuve Vatar, 1685 (Lilly BR845 .A4
+                1685).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f7dcb1a31d993f77160942a1ab612aa4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b8c97f800a3dcee31cb434a2705518ec" level="file">
+          <did>
+            <unittitle><persname>Dartmouth, George Legge, baron, 1648-1691, admiral.</persname>
+              Order to Mr. Bertie to pay a debenture to the Royal African company of
+              England.</unittitle>
+            <unitdate datechar="creation" normal="1686-01-13/1686-01-13" type="inclusive">1686,
+              January 13 -</unitdate>
+            <physdesc id="aspace_0e61faebfd68cafe0eb1bdb6babf7c97">Autograph document 1 p. 31
+              cm.</physdesc>
+            <container id="aspace_62d5dc3e0126668c10383122cfef0467" label="box" type="box"
+              >1</container>
+          </did>
+          <acqinfo id="aspace_6d139d6158da2d65f9e710b776c7a883">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2b8e56f1282e1b35462ebf72369b6fd4" level="file">
+          <did>
+            <unittitle>Classium &amp; generum plantarum.</unittitle>
+            <unitdate datechar="creation" normal="1600/1699" type="inclusive">17th century?
+              -</unitdate>
+            <physdesc id="aspace_6cb18bedb3b58aed72c0c1963f904d68">Autograph document viii+91 p. 19
+              x 12 cm.</physdesc>
+            <container id="aspace_146946ff86c0298172802b0265392192" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_a3c965179078f51282e18e347923780f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Latin</item>
+              <item>Index for 22 classes of plants precedes the text which includes only Classes
+                I-VIII</item>
+              <item>Written in black ink on paper</item>
+              <item>Bound in vellum</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d9b67306be3bd1d3b1d4e6d01d124b88">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. Harper lot 7789. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1c4f39fe0d2ab3fc05d14cda9ee34857" level="file">
+          <did>
+            <unittitle>Devotional Commonplace Book.</unittitle>
+            <unitdate datechar="creation" normal="1600/1699" type="inclusive">17th century
+              -</unitdate>
+            <physdesc id="aspace_2474afa93c1c74bd233f38ccbca3ad61">Autograph document 187 leaves 19
+              x 14 cm.</physdesc>
+            <container id="aspace_19666e70dcad53cc30a0daf6c87035f1" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_88faa699e5d0a3db86299995ca9c13e1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>The first 16 leaves are in Latin; the remainder are in English</item>
+              <item>Bound in vellum</item>
+              <item>There is a bookplate with the initials R. E. H. D.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0bb15d9576e4ffd885e2f7b578063875">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Mark J. Hanrahan, Banquette Book Shop, New Orleans, Louisiana. <date
+                normal="1964">1964.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_009a7648582c680f5ffb56d5815043d0" level="file">
+          <did>
+            <unittitle><persname>Harvey, William, 1578-1657, surgeon.</persname> Warrant authorizing
+              payment to Adrian Metcalfe, apothecary to Charles I, for medical supplies for the
+              household servants.</unittitle>
+            <unitdate datechar="creation" normal="1600/1699" type="inclusive">17th century
+              -</unitdate>
+            <physdesc id="aspace_6c51c8442659b6332e98cbad299edc61">Autograph document signed 1
+              leaves 17 cm.</physdesc>
+            <container id="aspace_c8ecfcae65fd92b0d930b71f00cbc9ec" label="box" type="box"
+              >1</container>
+          </did>
+          <scopecontent id="aspace_a1eabc408868722d2acac86489b3e76d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Dated Quinto die July</item>
+              <item>Portion (2 1/2 cm. from the right edge) bearing the year of the reign, the
+                surname and other words has been lost.</item>
+              <item>Document comparable in wording may be found in Geoffrey Keynes, <title
+                  render="italic">The Life of William Harvey,</title> Oxford, Clarendon Press, 1966,
+                page 280 (QP26 .H3 K38).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3ff1f21b10c432bec96b6f5897acd29d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Gordon Ray, 90 Park Avenue, New York, New York, 10016. <date normal="1971"
+                >1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_979854749724078fc4984a25ef37b985" level="file">
+          <did>
+            <unittitle><persname>Charles XII, king of Sweden, 1682-1718.</persname> Blonie, Poland.
+              Order to the War Commissariat to quarter the troops until more troops should
+              arrive.</unittitle>
+            <unitdate datechar="creation" normal="1705-10-26/1705-10-26" type="inclusive">1705,
+              October 26 -</unitdate>
+            <physdesc id="aspace_71561392c61e3e833ce41cdf19491edf">Autograph document signed 4 p. 20
+              cm.</physdesc>
+            <container id="aspace_7001d8d9e077cb2f032ff335f352d7cd" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_076b45715e188ce0987c431f391e3f8b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed: Carolus</item>
+              <item>In Swedish</item>
+              <item>Address leaf bears broken red wax seal</item>
+              <item>Accompanied by dealer's description of book from which the document was removed.
+                Typescript document signed, 1 p., 27.5cm., 1935, Nov. 22, signed in ink by Whitman
+                Bennett, 1883-1968, author, movie producer, rare book dealer.</item>
+              <item>Removed from <title render="italic">The History of Charles XII, King of
+                  Sweden,</title> by Voltaire, translated by John Joseph Stockdale. London, 1807
+                (Lilly DL732 .V913 1807).</item>
+              <item>Note in front cover reads: "Military doc. Charles XII of Sweden. Height of his
+                success, while fighting Russians in Lithuania."</item>
+              <item>Includes dealer's description of document as well as description of volume from
+                which it came</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_db4d0dc0c395dc5778833040eb5845d6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1982">1982.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ffe3742a3a754528f6adda847def095d" level="file">
+          <did>
+            <unittitle><persname>Flamsteed, John, 1646-1719, astronomer.</persname> Recommendation
+              for Joseph Crossthwaite who was employed as an "extraordinary laborer at the
+              Observatory" in Greenwich.</unittitle>
+            <unitdate datechar="creation" normal="1718-06-30/1718-06-30" type="inclusive">1718, June
+              30 -</unitdate>
+            <physdesc id="aspace_01aaf1d4653dba03e7f9be283e9ae9b8">Autograph document signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_0c3232bce5b1f950b8400cf2711d808c" label="box" type="box"
+              >2</container>
+          </did>
+          <acqinfo id="aspace_13e2ee6eb8c28fc429b8c909dcb7c838">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              unknown. Harper lot 12313. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_930be1a2508ea86b14b1fbf4360c54c0" level="file">
+          <did>
+            <unittitle>Meditationes philosophicae de deo, mundo, homine.</unittitle>
+            <unitdate datechar="creation" normal="1722/1722" type="inclusive">1722 -</unitdate>
+            <physdesc id="aspace_71d18e1dd1bcbbbc87ad9d7cdbaec65d">Autograph document 46 p. 17
+              cm.</physdesc>
+            <container id="aspace_fe33789b06fffe33638da805cdeb83c6" label="box" type="box"
+              >2</container>
+          </did>
+          <acqinfo id="aspace_d58cd5a73ce3457b722a243f233ef756">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Heinrich Meyer, Route 1, Emmaus, Pennsylvania. <date normal="1958"
+                >1958.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_009b66c6643e10f1b8a34b65310dcff4" level="file">
+          <did>
+            <unittitle>The Royal Household Book of King George II and Queen Caroline</unittitle>
+            <unitdate datechar="creation" normal="1727/1727">1727</unitdate>
+            <container id="aspace_8bc242f069b7ac4eecce8c85fa45abbd" label="Mixed Materials"
+              type="Box">13</container>
+          </did>
+        </c02>
+        <c02 id="aspace_2e65aa2a0190a0a983c2d3b26737b8cf" level="file">
+          <did>
+            <unittitle><persname>Vandermonde, Jacques François, -1746, physician.</persname> Extract
+              from the Pen-ts'ao chang-mu by Li Chi Tsin, beginning, "Traduction du Chinois en
+              françois, d'une histoire des drogues que porte pour titre <title render="italic">Kan
+                mo</title> ou principale extrait des auteurs qui ont ecrits de la medecine," and an
+              original essay beginning, "La Maladie que les Portuguais de l'Inde nomment Mordexin
+              est une indigestion d'estomac..."</unittitle>
+            <unitdate datechar="creation" normal="1730/1730" type="inclusive">1730? -</unitdate>
+            <physdesc id="aspace_d02dbeba6cd4bc097a3ceaa0ccc82a98">Autograph document 119 p. 36
+              cm.</physdesc>
+            <container id="aspace_bec711805457dd1008aadd3dc541556a" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_643379ad2dd3234c1eb89ead1fffb425">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in vellum</item>
+              <item>Pagination is numbered 1-111 and 150-168</item>
+              <item>Translation begins with the fifth book</item>
+              <item>Chinese characters of all names in the text written in corresponding
+                margin</item>
+              <item>Writer does not mention his own name but refers to his personal experiences at
+                Canton in 1728 and at Macao in 1729-1730</item>
+              <item>Present volume used by Edouard Constant Biot, 1803-1850, engineer, sinologue,
+                for his article in <title render="italic">Journal Asiatique,</title> VIII, Paris,
+                1839, p. 206-230.</item>
+              <item>Formerly in the library of Paul Pelliot, 1878-1945, orientalist; leaf with note
+                in Pelliot's hand laid in front of volume</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a48b257acf5fb6626d886c0ee9362456">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Alain Brieux, Paris. <date normal="1973">1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c6121319dee6171b008601bd0826fbea" level="file">
+          <did>
+            <unittitle><persname>Dereimery Chirurgim, Pierre.</persname><title render="italic"
+                >Traite des Operations de Chirurgie par demande Et par Reponse, Conforme a La
+                Reception Des aspirant a Cosme a paris ce ianuier 1735.</title></unittitle>
+            <unitdate datechar="creation" normal="1735-01/1735-01" type="inclusive">1735, January
+              -</unitdate>
+            <physdesc id="aspace_1f61aa22590377ec49c29cc8035dee96">Autograph document</physdesc>
+            <container id="aspace_d5fc944951b54402efdde55d5b0ce4f6" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_371a975bb8e248b21a80183ca1a7385e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Leather bound</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4a5cc0cab493a018263f4b59c1c908d5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. MacLeod's Books. 455 West Pender Street, Vancouver, B.C., Canada. <date
+                normal="2003">2003.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ac44a39cb8fa6e579b31f6a6fc309a38" level="file">
+          <did>
+            <unittitle><persname>Longstaff, James, Hagnaby England.</persname> To Samuel Reynardson,
+              Esq., In Queen Square, London England. Discusses the damage wrought by the seatide of
+              Feb. 16, notes that there "must be a new sea bank," and includes a reminder about
+              Queen Anne's bounty money.</unittitle>
+            <unitdate datechar="creation" normal="1735-03-03/1736-03-03" type="inclusive">1735/6,
+              March 3 -</unitdate>
+            <physdesc id="aspace_e09754f0120f8d96a1f8dbe22a143ffa">Autograph letter signed 4 p. 21
+              cm.</physdesc>
+            <container id="aspace_aab5477134a133b65dae56fb9d4c9df3" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_f901930153dd4c039e573d43081faa7c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Hagnaby was located at 53.17N latitude, 0.10E longitude according to <title
+                  render="italic">The Times World Gazeteer Index,</title> p. 321 (G103 .T58).</item>
+              <item>On verso are pencilled notes of the genealogy of the Wentworth family</item>
+              <item>Accompanied by several miscellaneous genealogical notes</item>
+              <item>Removed from Dugdale, <title render="italic">The baronage of England...</title>
+                London, Printed by T. Newcomb, 1675-1676 (Lilly CS421 .A2 D8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e9bf1875843940a29a1bdef7e4dfc301">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f26d9b046e12975da064f7bc4b93253f" level="file">
+          <did>
+            <unittitle><persname>Reynardson, Samuel, Esq., 1704-1797, clerk, author.</persname> To
+              Chris. Harris.</unittitle>
+            <unitdate datechar="creation" normal="1741-07-04/1741-07-04" type="inclusive">1741, July
+              4 -</unitdate>
+            <physdesc id="aspace_1409b70ee32426c5278679e64dee87f2">Autograph letter signed 1 p. 12
+              cm.</physdesc>
+            <container id="aspace_dd94a021dedc7cf7dae08cc6ff915602" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_c34ec8437c7c4d775770906f3cfa1518">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>An accounting to Chris. Harris for money due to the purchase of newspapers and a
+                book</item>
+              <item>Lower portion of manuscript missing</item>
+              <item>On verso arithmetic figurings and genealogical notes</item>
+              <item>Removed from Dugdale, <title render="italic">The baronage of England...</title>
+                London, Printed by T. Newcomb, 1675-1676 (Lilly CS421 .A2 D8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_875179b014f223e9e4ba2775ccf52b87">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_98ac5ca12cfbd770dfc93088aa801535" level="file">
+          <did>
+            <unittitle>Grenville, J. Receipt for money received from the Earl of Manlyfield, one of
+              the tellers of His Majesty's exchequer in part of an order in the name of the Right
+              Honorable William Pitt for the service of His Majesty's guards, garrisons, and land
+              forces.</unittitle>
+            <unitdate datechar="creation" normal="1748-10-21/1748-10-21" type="inclusive">1748,
+              October 21 -</unitdate>
+            <physdesc id="aspace_1b8190917ac08f7bbbd96daafcc6dee3">Document signed 1 p. 31
+              cm.</physdesc>
+            <container id="aspace_38145507dad97a7d102c6ce1b443e782" label="box" type="box"
+              >2</container>
+          </did>
+          <acqinfo id="aspace_7055b3b7841e7c6037dbdbbfc9ae30e3">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6f60f1486b6cb353c54a71822ddd5758" level="file">
+          <did>
+            <unittitle>Memoire des livres fournir à Monsieur de la Condamine par Durand.</unittitle>
+            <unitdate datechar="creation" normal="1749-04-22/1749-04-22" type="inclusive">1749,
+              April 22 -</unitdate>
+            <physdesc id="aspace_b12f8861625e23d1af40195147500ffe">Autograph document signed 1 leaf
+              35 cm.</physdesc>
+            <container id="aspace_c7247002a83dcabae3445c070dc5ffb2" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_433afed849b123737a627ab3b84694a3">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed by Durand in Paris</item>
+              <item>Lists 39 books and price of each</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7de5c13215dbefb7c068a0ad265cc6b0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_88d049c054c055a553a33ccf234d8170" level="file">
+          <did>
+            <unittitle>Dance, George. To the Worshipfull Committee for Letting the Bridge house
+              Lands [accompanied by two undated documents]</unittitle>
+            <unitdate datechar="creation" normal="1756-03-10/1756-03-10">1756, March 10</unitdate>
+            <container id="aspace_b1fd138a14291f0f7992e01e0073d0e7" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_572da728d53368e46329d55fee19a047" level="file">
+          <did>
+            <unittitle><persname>Hume, David, 1711-1776, philosopher.</persname> Edinburgh, Scotland
+              to "Sir." Refers to Hume's <title render="italic">Four
+              Dissertations.</title></unittitle>
+            <unitdate datechar="creation" normal="1757-02-27/1757-02-27" type="inclusive">1757,
+              February 27 -</unitdate>
+            <physdesc id="aspace_4af421043f98a7c09953df7acfb6f7d1">Autograph letter signed 2 p. 29
+              cm.</physdesc>
+            <container id="aspace_84488a1b8d46963d4b28b6b8941a4406" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_4e9dfa1a54673308fe31b45ea0ad742a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">The Life of David Hume</title> written by
+                himself, London, 1777 (Lilly B1497 .A2 1777).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_fe1782cc0c937fd2fad313460940344f">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_11134f41bbe98a246a119ac69289e5cf" level="file">
+          <did>
+            <unittitle>Glasford, Robert, Grenada. To James Glasford, Newbury, Massachussetts. Advice
+              on trading with the Windward Islands.</unittitle>
+            <unitdate datechar="creation" normal="1763-09-10/1763-09-10" type="inclusive">1763,
+              September 10 -</unitdate>
+            <physdesc id="aspace_78e83fa06eef44f8031124f00c4c9088">Autograph letter signed 2 p. 30
+              cm.</physdesc>
+            <container id="aspace_3896558618486e94b37765744198b9de" label="box" type="box"
+              >2</container>
+          </did>
+          <acqinfo id="aspace_9771b5ba84644e85cff5e315cc4a1967">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_875f361dcbd173fec3f885b86276362d" level="file">
+          <did>
+            <unittitle>George IV, king of Great Britain, 1762-1830. Copybook.</unittitle>
+            <unitdate datechar="creation" normal="1767-11-20/1767-11-20" type="inclusive">1767,
+              November 20 -</unitdate>
+            <physdesc id="aspace_a75c59949f49e0f511365fd27ecc20b2">Autograph document signed 21 p.
+              15.8 cm.</physdesc>
+            <container id="aspace_e175cc3b07136e163fb408ca33cbccbd" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_df6bef75227d8e751abb456fb5612a26">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Date from title page decorated with flourishes in ink which reads: His Royal
+                Highness George Prince of Wales, November 20th, 1767</item>
+              <item>George IV created Prince of Wales on Aug. 17th, five days after birth on Aug.
+                12, 1762</item>
+              <item>Pages numbered 1-18 in pencil</item>
+              <item>Copybook presents practice words for each letter of the alphabet except E-H and
+                V, and sentences for each letter except G, I, O, Q, and U-Z</item>
+              <item>Initial letter and sentence written in another hand as an example for
+                copying</item>
+              <item>The name "George" concludes each of the sentence pages beginning with
+                "Knowledge..."</item>
+              <item>Provenance statement in pencil inside front cover: from Dawson Turner's sale of
+                MSS &amp; autographs June 1859</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3d2b9006099a6b59a216068c4c4e1172">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fa065203c800ebb4857ace406e2ae0c6" level="file">
+          <did>
+            <unittitle>Ali, efendi, 1631-1692, compiler. Kitab al-fatawa.</unittitle>
+            <unitdate datechar="creation" normal="1768/1768" type="inclusive">1768 -</unitdate>
+            <physdesc id="aspace_e61acb0046910b84435b09ffff2f4a65">Autograph document 292 leaves 27
+              cm.</physdesc>
+            <container id="aspace_40f0e4a0372ad4ff7be34dd116d9af17" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_089a5db5d8f145e215b4c48aa38b5976">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Copy in Turkish (Ottoman) with marginal commentary in Arabic</item>
+              <item>Talik script in black and red, text ruled in gold</item>
+              <item>Decorative motif in gold, aqua, pink and blue following index</item>
+              <item>Bears stamp of copier, Khalil bin Muhammand, fl. 1768</item>
+              <item>Bound in black cloth</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_225af36198a8a94ed76a4f4f0d2222a0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Klaus Schwartz, 78 Freiburg in Breisgau, Immentalerstrasse 11, Germany.
+                <date normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_15d8c3d061cbb19d4ce0fd2a46a1bf1b" level="file">
+          <did>
+            <unittitle>Junta Annual y general de la Sociedad Anti-Hispana en el dia de Ynnocentes de
+              1776 y fin de fiesta en el Quarto del Marques de Primaldi.</unittitle>
+            <unitdate datechar="creation" normal="1776/1777" type="inclusive">1776-1777 -</unitdate>
+            <physdesc id="aspace_41a785d0cad78a13f88dc686c048e998">Autograph document 8 leaves 22
+              cm.</physdesc>
+            <container id="aspace_ce841d751d8947f11fcdb6b2e2bbad8a" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_c3bb9598aedf2e417b7484c549ed5114">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Vellum binding</item>
+              <item>A satirical play about Spain</item>
+              <item>Cast of characters includes Marques de Primaldi, Priego, Cancelariro, Spineli,
+                etc.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_03c1a8aab1619c746afde4223747163e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. Harper lot 24808. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_04210fdfbd377b65f8012c8c5df6dd54" level="file">
+          <did>
+            <unittitle>Compendium of Physic and Surgery.</unittitle>
+            <unitdate datechar="creation" normal="1780/1829" type="inclusive">1780-1829 -</unitdate>
+            <physdesc id="aspace_2af5fb681a30051a92e500fb33faefe8">Autograph document 358 p. 16 x
+              19.5 cm.</physdesc>
+            <container id="aspace_161954941b8bd799276add281a287022" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_42fe6946e36f2475af7cfe16831d0aac">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Leather back cover and quarter of front cover missing</item>
+              <item>Attributed to Joseph Flowerden, published by J. Nourse, London, 1769</item>
+              <item>Medical work concludes: Finis April 15, 1780</item>
+              <item>Further medical directions include: Howards Receipt for Curing the Lame
+                Distemper, Yaws, or almost any Corrupt Blood <emph render="italic">and</emph> To
+                Cure a Cancer</item>
+              <item>Dates inscribed in volume are: January 30, 1793 (weather record); 1798 (farm
+                record); 1829 (pencilled note), Alexander Bourbon Kentucky?</item>
+              <item>At end of volume, written dos-a-dos, are 18 pages of songs (2 leaves detached)
+                copied by Alexander Barnett, chiefly while at Camp Hicks Creek in South Carolina,
+                Dec. 28, 1780-Jan. 12, 1781</item>
+              <item>Names of John Brown, Congressman, and James Barnett, Capt. Jno. Barnett, John
+                Dykes, Solomon Levi, and John Taliaferro also appear</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_66d99dbdf3c0bd92d0196f433ec59ddb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Hamill and Barker, Chicago, Illinois. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3efc2b78e36dd1e6fb1c9629c5fdfb4d" level="file">
+          <did>
+            <unittitle><persname>Franklin, Benjamin, 1706-1790, printer, inventor,
+                statesman.</persname> Passy, France. To Thomas Pownall. Wishes to obtain
+              remuneration from John Almon for Amelia (Evans) Barry on account of <title
+                render="italic">by Thomas Pownall... published with Thomas Pownall's</title> by
+              Thomas Pownall... published with Thomas Pownall's <title render="italic">London, J.
+                Almon, 1776; is "authorized to treat of Peace whenever Great Britain is dispos'd to
+                it."</title> London, J. Almon, 1776; is "authorized to treat of Peace whenever Great
+              Britain is dispos'd to it."</unittitle>
+            <unitdate datechar="creation" normal="1781-11-23/1781-11-23" type="inclusive">1781,
+              November 23 -</unitdate>
+            <physdesc id="aspace_d0eb28ddf3aedd2fcf1c621d63ae54f8">Photostat 1 p. 31 cm.</physdesc>
+            <container id="aspace_f2eeb27d1df09de15416408c54658088" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_045deb2ca53c4c697617b3a1702e509b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Only photostat (not original) is present</item>
+              <item>Accompanied by: Thomas Pownall, Richmond, Surrey, England, to Benjamin
+                Franklin.</item>
+              <item>Copy of John Almon's "State of the Account of Gov. Pownall's Description of
+                America," with covering letter. Autograph letter signed 3 p. 13, 25, &amp; 30
+                cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e1f0a0acf1113c3b88042a8f3c8507fa">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1950">1950.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_75cdf42a50ed367bb1bb0aecccf0ab93" level="file">
+          <did>
+            <unittitle>George III. Commission to Frederick George Bourne</unittitle>
+            <unitdate datechar="creation" normal="1782-06-29/1782-06-29">1782, June 29</unitdate>
+            <container id="aspace_c277a3aa5d8237bd70164aa704d7ebae" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_b7b66586c2da0980b060b53b0b019727" level="file">
+          <did>
+            <unittitle><persname>Gibbon, Edward, 1737-1794, historian.</persname> Statement from I.
+              H. Thylmann to Edward Gibbon, countersigned by Edward Gibbon.</unittitle>
+            <unitdate datechar="creation" normal="1785-03-01/1785-03-01" type="inclusive">1783,
+              March 1 -</unitdate>
+            <physdesc id="aspace_1fc814ec7db7bd8b644df31ceefed34c">Autograph document signed 1 p. 22
+              cm.</physdesc>
+            <container id="aspace_b15e409ce814abcb9aaccc7cf97b1afb" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_fa5ec764b94da2d9c8f7f44f3bc9eeb9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Apothecary bill</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_88f4dc50ac8fca070d99564a5c34705d">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_51749901537ee5d7ca1bdfd5bb9f024e" level="file">
+          <did>
+            <unittitle>Commonplace book by unidentified compiler with poetry, song lyrics, essays,
+              aphorisms, and a nursery rhyme</unittitle>
+            <unitdate datechar="creation" normal="1783/1815" type="inclusive">1783-1815</unitdate>
+            <container id="aspace_1d3f64e17069bd74dd3097707dc45a9d" label="envelope" type="Bound"
+              >Bound</container>
+          </did>
+          <scopecontent audience="internal" id="aspace_894aa82e14ac01f4e35376c97b749f0b">
+            <head>Scope and Contents</head>
+            <list audience="internal" type="ordered">
+              <head>4 3/4" x 7 1/4" leather notebook containing 80 pages filled with approximately
+                50 entries, including:</head>
+              <item>"Death's Final Conquest by Shirley"</item>
+              <item>"A Dirge. By D'Urfey"</item>
+              <item>"A Character from Ramsays American Revolution / Aug 27th, 1782"</item>
+              <item>An extract from "Ramsays American Revolution / New York Nov: 25th 1783"</item>
+              <item>"The Wanderer: to the evening Star by Richard Nesbit"</item>
+              <item>"Mary Queen of Scotts Farewell to France"</item>
+              <item>"The Wizard of the Rock / W. M. Smith"</item>
+              <item>"Verses written by the Sea , in a Heavy Gale / Freneau"</item>
+              <item>"From Moore's Irish Melodies / 'The Vale of Avoca'"</item>
+              <item>An "Extract from Goldsmith's England"</item>
+              <item>"Extract from the Lady of the Lake / a Poem by Walter Scott, Esq."</item>
+              <item>"Lines written by Sir Walter Raleigh the night before his execution"</item>
+              <item>An extract "From Miss Bowdler's Essay on Politeness"</item>
+              <item>An extract "From Davis's travels in America / Philadelphia, Autumn of
+                1797"</item>
+              <item>"Sonnet to Pocahontas by Mr. Rolf"</item>
+              <item>"Extract from Wilson's Pedestrian excursion to the Falls of Niagara.
+                1800"</item>
+              <item>"Sonnet to a Fly... Decr 6th 1815"</item>
+              <item>"Thank you, pretty cow... Nursery Rhyme"</item>
+            </list>
+          </scopecontent>
+          <acqinfo audience="internal" id="aspace_51b02ca89fbfc16186434a09b8152827">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase: 2023. Kurt A. Sanftleben.</p>
+          </acqinfo>
+          <controlaccess>
+            <subject authfilenumber="sh85029002" source="lcsh">Commonplace books</subject>
+          </controlaccess>
+        </c02>
+        <c02 id="aspace_454589d4d6245cd366d3eae5b4109543" level="file">
+          <did>
+            <unittitle><persname>Priestley, Joseph, 1733-1804, theologian, scientist.</persname> No.
+              6, Little Spring Street, Shadwell, London, Eng. To Mr. Wilkins, Grocer in the Market,
+              Norwich, Eng. Re a minister to preach at Elsam.</unittitle>
+            <unitdate datechar="creation" normal="1791-04-19/1791-04-19" type="inclusive">1791,
+              April 19 -</unitdate>
+            <physdesc id="aspace_f98ff93cbc5a6bfdc3c90efe6df0589c">Autograph letter signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_fd8acae6e9c434db946c7e04d6a3933e" label="box" type="box"
+              >2</container>
+          </did>
+          <acqinfo id="aspace_d19a67c651781059af4ee23c0f22acc7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Marcham, dealer. <date normal="1952">1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5c49fa7deb4fa2b44d9ef992e114b9cf" level="file">
+          <did>
+            <unittitle><persname>Merlet, Jean François Honoré, 1761-1830, deputy and president of
+                the National Assembly;</persname><persname>Pierre René Choudieu, 1761-1838, deputy
+                and secretary of the National Assembly;</persname> and <persname>Joseph Marant,
+                1755-1843, deputy and secretary of the National Assembly.</persname> Decree of the
+              National Assembly proposing Jean Marie Roland de la Platière as minister of interior,
+              Joseph Servan de Gerbey as minister of war, and Etienne Clavière as minister of
+              contributions.</unittitle>
+            <unitdate datechar="creation" normal="1792-08-10/1792-08-10" type="inclusive">1792,
+              August 10 -</unitdate>
+            <physdesc id="aspace_daa1efe4200670b15bfa2470ed5ac43b">Autograph document signed 2 p. 31
+              cm.</physdesc>
+            <container id="aspace_021767856d51acb2fbc6cf3936e52499" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_1bb52b09a6ee7123f964029a870246ee">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Contemporary copy made Aug. 12, 1792, for Monsieur Servan de Gerbey</item>
+              <item>Document bears printed heading: Proces Verbaux Nationale Assemblee 1789 within a
+                wreathe</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4f86db540079b7e82f74e2da4b4788c7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Gilhofer and Ranschburg, Lucerne, Switzerland. <date normal="1973"
+                >1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8d7daf3184313c60f8907baef1038904" level="file">
+          <did>
+            <unittitle>France. Laws, statues, etc. 1774-1792 (Assemblée Nationale legislative). Loi
+              Relative aux Actes des Notaires. Du 9 September 1792...A Paris, le quatorzieme jour du
+              mois de september mil sept cent quatre-vingt-douze, l'an quatrième de la
+              liberté.</unittitle>
+            <unitdate datechar="creation" normal="1792-09-14/1792-09-14" type="inclusive">1792,
+              September 14 -</unitdate>
+            <physdesc id="aspace_6d91b539e5c5aaa1b079e1ce5253ea8a">Document signed 1 p. 32
+              cm.</physdesc>
+            <container id="aspace_3423c97db48c7b5deb9f5f47673e2ae0" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_9caa8d8d58a12bb1bb8cd427dd2d7c92">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On vellum, folded</item>
+              <item>Holograph signature of Georges Jacques Danton, 1759-1794, revolutionary
+                leader</item>
+              <item>Bears stamped seal in red: Au Nom De La Republique Française</item>
+              <item>Concerns wording on seal of notary acts; changed from <title render="italic"
+                  >Sous le Scel du Roi</title> to <title render="italic">Sous le Scel de la
+                  Nation</title></item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_370fb106850ada155455cba2e2528586">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Gilhofer &amp; Ranschburg, Lucerne, Switzerland. <date normal="1981"
+                >1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_eceacb9fc2fb440a2c1c4b54e68f06a2" level="file">
+          <did>
+            <unittitle>Testamento del Rey de Francia. Pariz 25 de Enero. Testamento de Luis
+              XVI.</unittitle>
+            <unitdate datechar="creation" normal="1792-12-25/1792-12-25" type="inclusive">1792,
+              December 25 -</unitdate>
+            <physdesc id="aspace_249f3b7e617c691ce892444a5740803e">Autograph document signed 4
+              leaves 21 cm.</physdesc>
+            <container id="aspace_4adab1c81f7c6ca29fb77a68abaf0864" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_b71785db6ad8ba0f596a3223c9b31a92">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Spanish copy of the Testament of Louis XVI, king of France, made January 25
+                after his execution on January 21, 1793</item>
+              <item>Many French editions published in 1793</item>
+              <item>Varies from the original in that the name Fernando precedes the name of Luis in
+                the signature</item>
+              <item>See English translation as given in Padover, <title render="italic">The Life and
+                  Death of Louis XVI,</title> D. Appleton-Century Company, 1939 (Lilly DC137 .P12),
+                pages 339-342.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e1037f1c830d3aad2ff82692020e4e71">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y., 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_007c9ddeb7d08191e65ac7d4c70153f4" level="file">
+          <did>
+            <unittitle>Three documents addressed to or concerning the pay commissioner of the French
+              Army of the coast of La Rochelle, June 10, 19, and 25, 1793.</unittitle>
+            <unitdate datechar="creation" normal="1793-06-10/1793-06-25" type="inclusive">1793, June
+              10-25 -</unitdate>
+            <physdesc id="aspace_9fb8601ae06888336932de693f69ffea">Autograph document</physdesc>
+            <container id="aspace_8b503833a0b8ac9f30e1b78bab8b471d" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_9f4686afd59480209a71d91e7b49639f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">Décrets de la Convention Nationale.</title>
+                Paris. 1793 (Lilly DC175 .A18).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0dedac29063d83c459be2ab8e732f172">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1985/1986" type="inclusive">1985-1986.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_993a7397f843793131566ce95248d9ad" level="file">
+          <did>
+            <unittitle><persname>Botta, Carlo Giuseppe Guglielmo, 1766-1837, physician,
+                historian.</persname> Pavigi... To Victor Modesto de Paroletti, Nice. Concerns an
+              exchange of letters and mentions several places.</unittitle>
+            <unitdate datechar="creation" normal="1793-09-01/1793-09-01" type="inclusive">1793,
+              September 1 -</unitdate>
+            <physdesc id="aspace_48eaaa6ac16070889a0b1ab06b2fabce">Autograph letter signed 2 leaves
+              20 cm.</physdesc>
+            <container id="aspace_cd5f93985ee45fef8374213c241b53bf" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_a03d7475554938c4d6c7876b6e83b715">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Italian</item>
+              <item>Dated "15 fructidoro anno 1"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_eb373dd3b0bc3c87bad5d64061d255ee">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y., 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_54b3601e4251b25d66f2b8656ead9580" level="file">
+          <did>
+            <unittitle><persname>Rowan, Alexander Hamilton, 1751-1834, United Irishman.</persname>
+              Newgate. To William Sampson, Esq., Belfast. Appreciates Sampson's "great trouble" in
+              compiling Rowan's trial, but fears the "claws of the Lyon."</unittitle>
+            <unitdate datechar="creation" normal="1794-03-26/1794-03-26" type="inclusive">1794,
+              March 26 -</unitdate>
+            <physdesc id="aspace_0f0676433a77e88203bc288cfd916320">Autograph letter signed 3 p. 23
+              cm.</physdesc>
+            <container id="aspace_8726c4fe2e644f6667a214c5f04b08cd" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_478ba274b341f8fff1f8896d7c096caa">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Certified by W. C. Cooke, Justice of Peace</item>
+              <item>Watermark: BUTTANSHAW</item>
+              <item>Removed from <title render="italic">Report of the trial of Archibald Hamilton
+                  Rowan, Esq....</title> Dublin, 1794 (Lilly DA483 .R6 1794).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_050432789af020ae4f1bba70dae32937">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_02be43a0158b115e397062d77b59786e" level="file">
+          <did>
+            <unittitle>Réquisition du Comité de Salut public. Paris, le six floréal l'an deuxième.
+              Requires that in accordance with the Décret of 27 Germinal that Citizen Aléxandre
+              Constantin, son of Guyot Laval "liquidateur" of the National Treasury be employed at
+              the place where he is.</unittitle>
+            <unitdate datechar="creation" normal="1794-04-25/1794-04-25" type="inclusive">1794,
+              April 25 -</unitdate>
+            <physdesc id="aspace_e7f6f38d4d65e801a309ddfffc9b7d8b">Printed form, filled in. 1 leaf
+              23.5 cm.</physdesc>
+            <container id="aspace_f0b2122420a72dee4d2417c65792c9ce" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_4b89628ac140369b7eeb1e8a302c9057">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>No. 313</item>
+              <item>Signed by members of the Committee: Jacques Nicolas Billaud-Varenne, Lazare
+                Nicolas Marguerite Carnot, Jean Marie Collot d'Herbois, and Jean Baptiste Robert
+                Lindet</item>
+              <item>For other Requisitions in compliance with the Décret of 27 Germinal, see those
+                dated Sept. 6, 1794, and n.d. (Billaud-Varenne) in Lafayette mss.</item>
+              <item>Paper watermarked: VT</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c27f1c1f1e9b0f5979e25af149e35ab1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Gilhofer and Ranschburg. <date normal="1973">1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_270f77f59689f4a37d1f55a2016e3b7d" level="file">
+          <did>
+            <unittitle><persname>Cottrell, John, naval officer.</persname> Navigational profiles.
+              Sailing directions from the Isle of Wight to the Anamba Islands as seen from the
+              "Glatton" in the service of the East India Company.</unittitle>
+            <unitdate datechar="creation" normal="1794/1794" type="inclusive">1794 -</unitdate>
+            <physdesc id="aspace_be4ad155ecefbac3e656836c3e08ef5b">Autograph document signed 84
+              leaves 22 x 32 cm.</physdesc>
+            <container id="aspace_088bc33bbf7e3e89a0273ae220abecea" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_1698bfd2bb81302eb0d1654223762082">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in brown half morocco</item>
+              <item>In black ink and green water colors on white paper with chain lines and
+                watermarks.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a08100bd3aae128e8486bad75d41935e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Maggs Bros. Ltd., 50 Berkeley Square, London, England. <date normal="1969"
+                >1969</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fdb2c170ae37caf0a0d99d64d822f34c" level="file">
+          <did>
+            <unittitle><persname>Louis Principe de Parme (i.e. Louis I, king of Etruria),
+                1773-1803.</persname> A Aranjuez Spain. To Francis James Jackson. Speaks of horses,
+              books, and Mr. Forster.</unittitle>
+            <unitdate datechar="creation" normal="1796-06-04/1796-06-04" type="inclusive">1796, June
+              4 -</unitdate>
+            <physdesc id="aspace_8a574277eeea7ad8bcfefdd3fee31fd4">Autograph letter signed 4 p. 21
+              cm.</physdesc>
+            <container id="aspace_7274447bbe455e55d4a30be772255a49" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_c26a9089e7c79e3e639b42b9407a03ca">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+              <item>Water stained</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c52b86ea68648da859b1368d512c46d1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_13e2fbf25726050d73d9526ace07ac85" level="file">
+          <did>
+            <unittitle>Memorias sobre la fundación de la congregacion de las misiones extranjeras en
+              París Macao, China.</unittitle>
+            <unitdate datechar="creation" normal="1796-08-21/1796-08-21" type="inclusive">1796,
+              August 21 -</unitdate>
+            <physdesc id="aspace_4232a54e8edd26862eb629002b60d0f2">Autograph document 23 leaves 21
+              cm.</physdesc>
+            <container id="aspace_fe9f1532c4c9d1d51fde97de206035ff" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_bce7858124260b8feec3d10ef50a632d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Vellum binding</item>
+              <item>Relates the founding of the "congregacion de los misioneros extranjeros," their
+                goals of converting unbelievers, founding missions in the Orient, and history of
+                their successes in the Orient</item>
+              <item>Bound with this is Carta de San Agustín á Xisto, n.d. Autograph document 51
+                leaves 21 cm.</item>
+              <item>Relates philosophic views of the Catholic religion</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6801218b2a852c46f140899906d40adb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. Harper lot 24957. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c2d959a3b3aab420b18ebcefb3ef5153" level="file">
+          <did>
+            <unittitle><persname>Marsden, William, 1754-1836, orientalist.</persname> London. To "My
+              dear Sir." Deals with the publication of his catalog of books, collecting titles of
+              books for a catalog of oriental works, and probably printing a dictionary of the
+              Malayan language.</unittitle>
+            <unitdate datechar="creation" normal="1797-08-04/1797-08-04" type="inclusive">1797,
+              August 4 -</unitdate>
+            <physdesc id="aspace_da3ed2c48921bb51fcdb38a767b16094">Autograph letter signed 4 p. 24
+              cm.</physdesc>
+            <container id="aspace_b419e72fbc6b7c69d9c0fe51288107a8" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_0a608ac99350078a80544e4522d95252">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from William Marsden, <title render="italic">Bibliotheca Marsdeniana
+                  Philologica et Orientalis...</title> London, Printed by J. L. Cox, 1827 (Lilly
+                Z7050 .M36 Mendel).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_886ede17dfa75fad4af037e41a8e6abd">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1973">1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_88f3ae22dbb95b5bfe45188d72a58e22" level="file">
+          <did>
+            <unittitle><persname>George IV, king of Great Britain, 1762-1830.</persname> Carlton
+              House. Order to Messrs. Drummond &amp; Co., Bankers, Charing Cross, to pay the Earl of
+              Jersey the sum of 2300 pounds.</unittitle>
+            <unitdate datechar="creation" normal="1797-10-19/1797-10-19" type="inclusive">1797,
+              October 19 -</unitdate>
+            <physdesc id="aspace_5c09a5fbbf1c500b1f3bf8afa0bf9d5b">Autograph document signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_8d32a381de1df504562203f1cc7f48d0" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_f91b656a9db8f0ac5d996a302e85f21c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed as Prince of Wales</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0ebfd7c3ac57bb6496bb859832c5407c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b2d039e153a7ddc98b9c2eec61a7c40a" level="file">
+          <did>
+            <unittitle><persname>Morris, Margaret (Hill), 1737?-1816, author.</persname> To Samuel
+              Powell Griffitts. Comments on health of the family.</unittitle>
+            <unitdate datechar="creation" normal="1797-10-28/1797-10-28" type="inclusive">1797,
+              October 28 -</unitdate>
+            <physdesc id="aspace_e1117dba2de20b2ec274fccf09cb235f">Autograph letter signed 3 p. 20
+              cm.</physdesc>
+            <container id="aspace_527f144bf942541c7d9347d69d6763ac" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_0659022e196270b7707fb6ac20c35899">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on inside of front cover of Benjamin Rush's <title render="italic">An
+                  account of the bilious remitting yellow fever...</title> Philadelphia, Printed by
+                Thomas Dobson, 1794 (Lilly RC211 .P5 R75).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_986e44e368058229ea5c464a9b94654a">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b8255e1dbff2a2298c562e25cb1378fb" level="file">
+          <did>
+            <unittitle>Journal d'un Voyage... India and South Africa.</unittitle>
+            <unitdate datechar="creation" normal="1798-02-26/1799-01-26" type="inclusive">1798,
+              February 26-1799, January 26 -</unitdate>
+            <physdesc id="aspace_1a6f36dab9d105b585be8acd985e5524">Autograph document 65
+              p.</physdesc>
+            <container id="aspace_5e72b10b6c2595723a7a698604b6cabb" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_9b5eaad6ac994f3a3685c41ea87b3d7d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Corrections and amendments in another hand</item>
+              <item>Early, apparently unpublished manuscript account of a voyage from India to the
+                Cape of Good Hope in the late eighteenth century. Prompted by close friends, the
+                author's account describes a region then little known to the French. The Napoleonic
+                Wars were underway at this time and the author speculates on the military campaign
+                in Egypt and its ramifications for the rest of the continent.</item>
+              <item>Author includes considerable ethnographic information, including speculations on
+                the political impact of the region's geography, differences between tribes, and a
+                physical description of the Caffres and their marriage customs, religion, and
+                agriculture, as well as notes on the natural history encountered.</item>
+              <item>Of linguistic interest is the six page vocabulary at the rear of the
+                document</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_29705d4d661fa48532e7eea5271d6b34">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Maggs. <date normal="2005">2005.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_50636393dbc009a2f0e0fd78455159bb" level="file">
+          <did>
+            <unittitle><persname>Granger, James, 1723-1776, biographer.</persname> Notes and drafts
+              for <title render="italic">A biographical history of England...</title></unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_0e7e05f5beb2f88a88238096ffc1ffb2">Autograph document 194 leaves
+              18-21 cm.</physdesc>
+            <container id="aspace_54b9744f4062cae7069195161ebea4cf" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_6def943872ae41e5849fa654b0af9421">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in modern half calf and tan cloth</item>
+              <item>Note on first page: "Bought at Mr. Upcott's sale June 22nd 1846"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3edc598aa93697456c742bbbcb6a6ed1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Colin &amp; Charlotte Franklin, Oxford, England. <date normal="1989"
+                >1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_35ff82ad4051791b00a6f248658cd318" level="file">
+          <did>
+            <unittitle><persname>Granger, James, 1723-1776, biographer.</persname> Notes concerning
+              Joseph Ames' <title render="italic">A catalogue of English
+              heads...</title></unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_54ff5de78f278cdf858130a0a15c381c">Autograph document 4, 185, 182 p.
+              21.5 cm.</physdesc>
+            <container id="aspace_3e7747f4ab626aa2bca4cf35ebee219c" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_38ae3fbd211bc77cedbe2ab71b3bfb3c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in modern half calf and tan cloth</item>
+              <item>Signature of William Richardson on p. 1</item>
+              <item>Note on p. 3: "Bought at Mr. Upcott's sale June 22nd 1846"</item>
+              <item>Granger's notes are on and interleaved with Joseph Ames, <title render="italic"
+                  >A catalogue of English heads,</title> London: Printed by W. Faden for the editor,
+                1748 (Lilly NE265 .A5 copy 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b6d5712d18599e757ff4f4d702d78ed6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Colin &amp; Charlotte Franklin, Oxford, England. <date normal="1989"
+                >1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_12e4cde2fb1888d514528b1b2ed51235" level="file">
+          <did>
+            <unittitle>Oath of allegiance to King George II.</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_baff22bfc524bc3446fb3d55d4f67f99">Document signed 2 p. 31
+              cm.</physdesc>
+            <container id="aspace_2556a8327078729129b728e89c921ae9" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_dd1ccfdb1b597763ff4646423a75562f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed: Samuel Glover, John Bartoll, Jr., and Richard Newhall</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_409a02c4a0dad0133ab4d05a935446f1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Josiah Quincy Bennett. Bloomington, Indiana. <date normal="1990"
+              >1990.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_627bd98f4474cb2d8440af8a5e238cad" level="item">
+          <did>
+            <unittitle>Pharmacist's Recipe Book</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th
+              century</unitdate>
+            <physloc audience="internal" id="aspace_094068c88a3c3972d70db6eefdbb9310">Lilly -
+              Stacks</physloc>
+            <container id="aspace_7050723a64a541f74bba713918cd3d6f" label="bound" type="Bound"
+              >Bound</container>
+          </did>
+        </c02>
+        <c02 id="aspace_14c05628181a5400bfab871b6fd72f47" level="file">
+          <did>
+            <unittitle>The Princes Prayer and Speech to his army befor [sic] the Battle of
+              Gladsmuir.</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_989b02736ebeb0103d18f544f5cb00de">Autograph document 1 p. 28
+              cm.</physdesc>
+            <container id="aspace_9c0c2139515cac42a2e17409a8827b84" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_0d38a58e4ac3282bc628fc3b6abd40d4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Contemporary copy of prayer offered about September 21, 1745</item>
+              <item>Watermark: Arms of Amsterdam; resembles Heawood No. 401 (Lilly TS1080 .P183) and
+                Churchill No. 64 (Lilly Z237 .C5).</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_979ecb19f02920f9b2c9c90a97b6cb51">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. James Bruce Martindale Jr., Dallas, Texas. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6aeb050191b89c6d0d7bd38e9da3e196" level="file">
+          <did>
+            <unittitle>"Remembrances for Order and Decency to be kept in the Upper House of
+              Parliament by the Lords when His Majesty is not there. Leaving the Solemnity belonging
+              to His Majesties coming to be Marshall'd by those Lords to whom it more properly
+              Appertains."</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_5cadc41f12c55ba3a24a042021ccd369">Autograph document 121 p. 17
+              cm.</physdesc>
+            <container id="aspace_41ce4ed9cbe2074a349f685de2f217ca" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_1edfd90917e6081bea5d15e28e046886">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hants, England. <date
+                normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_de50b38717f8770773ca2e10afd7940d" level="file">
+          <did>
+            <unittitle>Supuesto El hecho que lo. El memorial asustado, tiene muy presente esta Rl
+              Audiencia, se funda en este primero punto que el Casso de la materia sujeta, no se
+              Comprehende en la desicion del Capitulo 14 Setc 25 de Regularibus, en el Santo
+              Consilio de Trento.</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_97f1689f52064a663b2d90e9ce90ec07">Autograph document signed 84
+              leaves 30 cm.</physdesc>
+            <container id="aspace_be01e7f40e5bb549b9b84e5483fd55ca" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_7289f646cbf8f6f68e354d2495ff611c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Sewn but lacking covers</item>
+              <item>In Spanish with quotations in Latin underlined</item>
+              <item>On the violations of a decree of the Council of Trent concerning a sermon
+                delivered by a member of one of the religious orders</item>
+              <item>Divided into six parts</item>
+              <item>Signed C.W.S. Joachin</item>
+              <item>Probably early 18th century: most recent date in text is 1677 (leaf 10v);
+                watermark of three circles surmounted by a cross compare favorably (but not
+                identically) to those of paper laid in Madrid in early 18th cent.</item>
+              <item>See <title render="italic">Monumenta Chartae Papyraceae Historiam
+                  Illustrantia,</title> Paper Publication Society in Holland, 1950- (Lilly TS1080
+                .P183) Vol. 1, Nos. 273 (Madrid, 1749), 279 (Madrid, 1723), 297 (Madrid, 1723); Vol.
+                12 Pt. 2, Nos. 1390 (1721), 1939 (1737).</item>
+              <item>Extraneous note laid in</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d7cdc2bdfe0f9f946598db069c7f3f45">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y., 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_34777c5785360bd7b48199a738b41d0b" level="file">
+          <did>
+            <unittitle>Recueil des Recepts.</unittitle>
+            <unitdate datechar="creation" normal="1700/1799" type="inclusive">18th century
+              -</unitdate>
+            <physdesc id="aspace_8d90172ad76f5860e9182e4b9a4613e1">Autograph document 122 p. 22
+              cm.</physdesc>
+            <container id="aspace_cb719a3c6e94ed532c744f1450dc0087" label="box" type="box"
+              >2</container>
+          </did>
+          <scopecontent id="aspace_8537b6af01e5f53162f920a89634c195">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In French</item>
+              <item>Sewn in vellum</item>
+              <item>Appears to be medicinal recipes</item>
+              <item>Bookplate inside front cover: Raymond Oliver</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_91ac9eb7444d07056c63a9b506b9b339">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Pierre Beres, Paris, France. <date normal="1994">1994.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4fe8f874aebd278127be3a7fd506796d" level="file">
+          <did>
+            <unittitle><persname>Wilkinson, James, fl. 1800.</persname> Journal of a journey on the
+              continent. A detailed account of his travels beginning with his arrival at Elsinore,
+              Denmark, then Copenhagen, Konigsberg, Danzig, back to Elsinore and on to England.
+              Included are a number of sketches of wagons, fortifications, guns, etc.</unittitle>
+            <unitdate datechar="creation" normal="1800-06-28/1800-09-05" type="inclusive">1800, June
+              28-September 5 -</unitdate>
+            <physdesc id="aspace_f396399d3e0f5081faf878876d5b56da">Autograph document signed 71
+              leaves 21 x 35 cm.</physdesc>
+            <container id="aspace_4c90b79cb1c75114a0b2273c9b3c382f" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_3f871fb1aad893fd0c77956ddf76284f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hants, England. <date
+                normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6a1e95eb73baa0cfe677031c4c45828c" level="file">
+          <did>
+            <unittitle><persname>Le Père, Jacques Marie, engineer.</persname> Cairo, Egypt. To
+              Michael Ange Lancret. Discusses flooding of the Nile and its impact on the canal at
+              Alexandria. States that backing and resources are available to continue the work on
+              the canal to Suez.</unittitle>
+            <unitdate datechar="creation" normal="1800-07-03/1800-07-03" type="inclusive">1800, July
+              3 -</unitdate>
+            <physdesc id="aspace_f8dcb3b97f31f3a0e54ba2788fb224b2">Autograph letter signed 2 p. 32
+              cm.</physdesc>
+            <container id="aspace_c48a541928756b502850d36e284c11f4" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_a0bf2f9f8fe254ef7df97f7f19b4097b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In French</item>
+              <item>Letterhead: Génie Civil, Republique Française, L'Ingénieur en Chef, Directeur
+                des Ponts et Chaussées</item>
+              <item>Appended is a letter from Le Père to Lancret dated July 31, 1800. Autograph
+                letter signed 2 p.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d009e02c6d0667af2cf1b3ce29482ce1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. G. Sabbagh, Paris. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_531188a1bb74a1d6c193ba93b3be3452" level="file">
+          <did>
+            <unittitle><persname>Le Père, Jacques Marie, engineer.</persname> CAiro, Egypt. To
+              Michel Ange Lancret. Discusses damaged canal dikes at Alexandria. Orders him there to
+              see to repairs, and offers funds for repairs and continued work on the canal to
+              Suez.</unittitle>
+            <unitdate datechar="creation" normal="1800-07-07/1800-07-07" type="inclusive">1800, July
+              7 -</unitdate>
+            <physdesc id="aspace_7e2af0fbca143836344a8c866b22155c">Autograph letter signed 2 p. 32
+              cm.</physdesc>
+            <container id="aspace_e9619be08257b060822a9a3693dcf73b" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_cae1cc461f7ea277ecfbae236581c9e8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In French</item>
+              <item>Letterhead: Génie Civil, Republique Française, L'Ingénieur en Chef, Directeur
+                des Ponts et Chaussées</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_91198057099e79548cfd088f8be464aa">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. G. Sabbagh, Paris. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ed5d3e226f51ad9e6b02c0479fb4d7d3" level="file">
+          <did>
+            <unittitle>Plan for enclosing certain piece of land; seeks addressee's help in
+              persuading others involved to agree.</unittitle>
+            <unitdate datechar="creation" normal="1800/1800" type="inclusive">Ca. 1800? -</unitdate>
+            <physdesc id="aspace_e29bd06763dbe3d11c2eb8988db6f731">Autograph letter 2 p. 23
+              cm.</physdesc>
+            <container id="aspace_bde03ccd1c035e361e712de1ae60efe6" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_54efca40c51c43a058b12e163aeab473">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>End of letter missing</item>
+              <item>Dated as "late 18th or early 19th cent." by William Thomas Morgan, profesor of
+                English History, Indiana University.</item>
+              <item>Accompanied by note that reads "rather important for the history of
+                enclosures"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6dcacd6f1671e1be264cca3284a837a4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a73e72ad00fb4a9238557e2b4cddf64b" level="file">
+          <did>
+            <unittitle><persname>Coleraine, George Hanger, 4th baron, 1751?-1824, army
+                officer.</persname> To Capt. Abraham Bosquett, No. 2 Great St Andrews Hill, Boston
+              Commons. Will inquire of Lord Hobart of the "Board of Controal" for an "occupation"
+              for Bosquett's friend.</unittitle>
+            <unitdate datechar="creation" normal="1801-03-09/1801-03-09" type="inclusive">1801,
+              March 9 -</unitdate>
+            <physdesc id="aspace_5ffbab509b2272d477f3b1a340a3384e">Autograph letter signed 2 p. 20.5
+              cm.</physdesc>
+            <container id="aspace_56dfae9f9c43d1fd0cb4158e5c206cf2" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_ae4d56dbf7756c70ec25c9fa873339b9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Phillips ms. 24560</item>
+              <item>Stamped in red on address leaf (2nd page): 8 o'Clock 10+MR 1801 M.D.</item>
+              <item>Removed from Coleraine, <title render="italic">The life, adventures, and
+                  opinions of Col. Hanger...</title> London, Printed for J. Debrett, 1801 (Lilly
+                DA506 .C7 L72 1801).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c13b6e0f858ce697584b34818a43594f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2cf42b61677c6292648b5e5a2a3853a0" level="file">
+          <did>
+            <unittitle><persname>Waterhouse, Benjamin, 1754-1846, physician.</persname> Cambridge,
+              Massachusetts. To Dr. Lyman Spalding, Portsmouth, New Hampshire. "Will you as speedily
+              as you can put me up sealed in a quill some of your smallpox matter? ...We want it to
+              test the kine pock patients who were inoculated."</unittitle>
+            <unitdate datechar="creation" normal="1802-10-13/1802-10-13" type="inclusive">1802,
+              October 13 -</unitdate>
+            <physdesc id="aspace_baa339554d14afe8fc152bec75c92497">Autograph letter signed 1 p. 23
+              cm.</physdesc>
+            <container id="aspace_14e7da15b82c954749be4ca9cbc1e088" label="box" type="box"
+              >3</container>
+          </did>
+          <acqinfo id="aspace_605cf1e41fe6f2b9b83a5add398eabff">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Goodspeeds Book Shop, 18 Beacon Street, Boston 8, Massachusetts. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0dc76b03b37630677263822b71869617" level="file">
+          <did>
+            <unittitle><persname>Nelson, Horation Nelson, viscount, 1758-1805, naval
+                officer.</persname> Victory off Toulon. To John Hookham Frere. Deals with desertion
+              of seamen and marines.</unittitle>
+            <unitdate datechar="creation" normal="1803-09-06/1803-09-06" type="inclusive">1803,
+              September 6 -</unitdate>
+            <physdesc id="aspace_7c5899383b3d06403717b560bccf54c4">Autograph letter signed 4 p. 24
+              cm.</physdesc>
+            <container id="aspace_a0f65a805875c3632481b54811a0f61b" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_2a5b118061899e7ca6315ab781798e98">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1973bb2dcab18f2ca512f8b6b3ee30fe">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b4a2c7d27455c940f2c50e142d0e9ef9" level="file">
+          <did>
+            <unittitle>Poems by D.F.B.R. Many of the poems deal with death.</unittitle>
+            <unitdate datechar="creation" normal="1804-04/1820-01" type="inclusive">1804,
+              April-1820, January -</unitdate>
+            <physdesc id="aspace_91fdb9904a407e69b93f5e47c2a7cf9f">Autograph document signed 79 p.
+              20 cm.</physdesc>
+            <container id="aspace_f60aa785f572abd1d37018bc66b34b4a" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_f09f0d1156ef29f19d8c97771fc95948">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Kelso, deceased, Linton, Indiana. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_762630988b0085798f4a0a6726f7cb67" level="file">
+          <did>
+            <unittitle>George III, king of Great Britain, 1738-1820. Signature cut from
+              document.</unittitle>
+            <unitdate datechar="creation" normal="1805/1805" type="inclusive">1805 -</unitdate>
+            <physdesc id="aspace_8a13a360b742afc35e6ced4f766fb30a">Document signed 1 p. 12
+              cm.</physdesc>
+            <container id="aspace_64479d8c7b8267d213db0998ae92981e" label="box" type="box"
+              >3</container>
+          </did>
+          <acqinfo id="aspace_9bcbd075a6a8be278d348a9f333a235e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift of Miss Kathryn Troxel. <date normal="1946">1946.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1c177cd59c7ab80ed29bd5b3783b0c22" level="file">
+          <did>
+            <unittitle><persname>Simmons, thomas Jefferson Nichols, 1830-?, minister, Methodist
+                Episcopal church, Ohio conference and Illinois conference.</persname> Fourteen
+              miscellaneous papers.</unittitle>
+            <unitdate datechar="creation" normal="1806-03-10/1887-11-29" type="inclusive">1806,
+              March 10-1887, November 29 -</unitdate>
+            <physdesc id="aspace_aac2843e5def4581daffda91d6c1d951">Autograph document signed 25 p.
+              13-33 cm.</physdesc>
+            <container id="aspace_2246343610464749f70e393be95a1adb" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_870bc0098a16ff5e08323bc31fc78044">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes family record of births, deaths, and marriages, March 10, 1806 -
+                September 7, 1856.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c8645d853cae5c987c5dea94fd6e9c0d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9cf5550ecd847329563672b0e4530d27" level="file">
+          <did>
+            <unittitle><persname>Bodoni, Giovanni Battista, 1740-1813, printer.</persname> Parma,
+              Italy. To Francesco Cancellieri, superintendant of the Stamperia di propaganda in
+              Rome.</unittitle>
+            <unitdate datechar="creation" normal="1806-09-01/1806-09-01" type="inclusive">1806,
+              September 1 -</unitdate>
+            <physdesc id="aspace_66363310863f0fdd602d07e4f153ed22">Autograph letter signed 3 p. 24
+              cm.</physdesc>
+            <container id="aspace_0d5843c29f9afef7096b44ff9629a146" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_fa1ed85a8163e91e9cb80b45a52de70d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Giovanni Battista Bodoni's <title render="italic">Manuale
+                  tipografico del cavaliere Giambattista Bodoni...</title> Parma, Presso la Vedova,
+                1818 (Lilly Z250 .B6).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f5163f5965aa926fa70f036ed20f970e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1958">1958.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_1d36a96de96aa8a46fa353b02c5f42e8" level="file">
+          <did>
+            <unittitle>Maps, etc. of France</unittitle>
+            <container id="aspace_f078dda07c6c21df3c67e7c1c4fbf6c3" label="Mixed Materials"
+              type="Map Case">Lilly - 5</container>
+          </did>
+        </c02>
+        <c02 id="aspace_da85c210ea47785d86029d428cb1be5f" level="file">
+          <did>
+            <unittitle><persname>Johnson, William B., teacher.</persname> Cyphering
+              book.</unittitle>
+            <unitdate datechar="creation" normal="1810-10-12/1811-05-16" type="inclusive">1810,
+              October 12-1811, May 16 -</unitdate>
+            <physdesc id="aspace_baeab3f8aa8e1c10361e63eaf04e5c8f">Autograph document 485 p. 37
+              cm.</physdesc>
+            <container id="aspace_c90f3cb535c4e93673592e621013a9d3" label="box" type="box"
+              >12</container>
+          </did>
+          <acqinfo id="aspace_205a1a85a1040b3c7b31a252e8db9f92">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Kelso, deceased, Linton, Indiana. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fbe84a6827ecba0d54f34383ab82580c" level="file">
+          <did>
+            <unittitle><persname>Tennyson, George, 1750-1835.</persname> Receipt to Thomas Peacock
+              for rent of a farm due to Henry Dalton.</unittitle>
+            <unitdate datechar="creation" normal="1812-06-27/1812-06-27" type="inclusive">1812, June
+              27 -</unitdate>
+            <physdesc id="aspace_3cb9f90635622f029de9c91a0ede336e">Document signed 1 p. 8
+              cm.</physdesc>
+            <container id="aspace_2085cbefc68d010d8433ee418c4320ed" label="box" type="box"
+              >3</container>
+          </did>
+          <acqinfo id="aspace_19eb663c1aa16c5a891e0ed9dbd2fda0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_35f16fc263370b9be46f2b814c89d35d" level="file">
+          <did>
+            <unittitle>McNeill &amp; Co., ship brokers. Volume of copies or drafts of letters from
+              and to the ship brokers, McNeil &amp; Co., and the owners of the "Claudius" and
+              "Pallas," and eleven pages of accounts relating to the "Claudius."</unittitle>
+            <unitdate datechar="creation" normal="1812-12-24/1818-04-17" type="inclusive">1812,
+              December 24-1818, April 17 -</unitdate>
+            <physdesc id="aspace_779ba590b2ac9910a6b1bd68c5105365">Autograph document 69 p. 20 x 32
+              cm.</physdesc>
+            <container id="aspace_5edf62e66963b8e3011a7e08b53d81fc" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_7c292a872a1cda2aa79a64a308bf37d7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Marbled wrappers</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_95bbc22fd144f2eff853538ea9c4fb91">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_565a9126b59bbd3b102fa71514bc68ba" level="file">
+          <did>
+            <unittitle><persname>Gage, Sir Thomas, bart., 1780 or 81-1820.</persname> Hengrarve. To
+              "Dear Sir." Unable to be in town for "the Catholic Meetings."</unittitle>
+            <unitdate datechar="creation" normal="1813-04-09/1813-04-09" type="inclusive">1813,
+              April 9 -</unitdate>
+            <physdesc id="aspace_a8b844da1e7919adb80dd3228b083b80">Autograph letter signed 1 p. 23
+              cm.</physdesc>
+            <container id="aspace_5a9320ad326cf5840c8264c66ba61ada" label="box" type="box"
+              >3</container>
+          </did>
+          <acqinfo id="aspace_0e38a1f7a9283c70b5be41cf77ae9e0d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_727dfa030ee7c7f860481ef06e79c31a" level="file">
+          <did>
+            <unittitle><persname>Birkbeck, Richard.</persname> Cash book and diary. Wanborough
+              Surry, England.</unittitle>
+            <unitdate datechar="creation" normal="1813/1813" type="inclusive">1813 -</unitdate>
+            <physdesc id="aspace_b2fe7f5964646b0c9927d7062eb58044">Autograph document signed 112, 32
+              p. 18 cm.</physdesc>
+            <container id="aspace_4b154947f7af1b97d1d0c3bacc391f03" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_2db934b76a93dbb03d33e359cbabd9bf">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Printed appendix of addresses, events, births, deaths, marriages, etc. for 1811
+                and 1812.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3f1ab3eaab65337f9692fe733f7326e8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Midland Rare Book Company, Mansfield, Ohio. <date normal="1944/1945"
+                type="inclusive">1944-1945.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e17b9fc412e04cdae276fe22c98b952f" level="file">
+          <did>
+            <unittitle><persname>Saul, Joseph, fl. 1832.</persname> Green Row. To Mr. Dickinson,
+              Seaton Iron Works, Workington. Refers to models of castings for a "Thrashing
+              Machine."</unittitle>
+            <unitdate datechar="creation" normal="1814-06-15/1814-06-15" type="inclusive">1814, June
+              15 -</unitdate>
+            <physdesc id="aspace_1f38847386e3f782cf45d0153aeae1d3">Autograph letter signed 1 p. 25
+              cm.</physdesc>
+            <container id="aspace_7e78fb05e606bfd039bf238d15c04d5b" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_60aef89c3a2cfc467e7f532b0c9837db">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from J. Saul, <title render="italic">Rhymes and reminiscences,</title>
+                London Whittaker, Treacher, and Arnot; Poole and Edwards; and Charles Thurnam,
+                Carlisle, 1832 (Lilly PR5299 .S174 R7).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9198e66d87469764dd1646d4c8d0246c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b91c205cdeb3202490c10daad925b191" level="file">
+          <did>
+            <unittitle><persname>Jones, George.</persname> Deposition relating to land owned by
+              Abraham Markle in Upper Canada.</unittitle>
+            <unitdate datechar="creation" normal="1815-12-01/1815-12-01" type="inclusive">1815,
+              December 1 -</unitdate>
+            <physdesc id="aspace_62adef6a7aa3fe169c1a94a5d521c924">Document signed 2 p. 31
+              cm.</physdesc>
+            <container id="aspace_6775be0df8cf400c9b302c6977345f6d" label="box" type="box"
+              >3</container>
+          </did>
+          <scopecontent id="aspace_7d8c202e644a27adec655d382d97f50a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Sworn to before Joseph Richardson, justice of the peace, Ontario County, New
+                York</item>
+              <item>Includes typescript</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_992b8ec29057589c2cebe4c4ebfa4445">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Augustus R. Markle, 1229 Roosevelt, Flint, Michigan. <date normal="1956"
+                >1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cf6a0a0db998414b3be1b5240d0c98d9" level="file">
+          <did>
+            <unittitle><persname>Londonderry, Robert Stewart, 2d marquis, 1769-1822,
+                statesman.</persname> Vienna. To William Richard Hamilton. Concerns diplomatic
+              appointments and the Portuguese project.</unittitle>
+            <unitdate datechar="creation" normal="1815-12-25/1815-12-25" type="inclusive">1815,
+              December 25 -</unitdate>
+            <physdesc id="aspace_bbd0b386bcc78156068f0bed948e28cd">Autograph letter signed 3 p. 23
+              cm.</physdesc>
+            <container id="aspace_5c51ada55ab87f87fa694ba9e56200d3" label="box" type="box"
+              >3</container>
+          </did>
+          <acqinfo id="aspace_6d0295bf7d32c8e76d8a9be0f2692d7d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Maggs Bros. Ltd., 50 Berkeley Square, London W1, England. <date
+                normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2269a09bbb02183e14470f5b78f29d95" level="file">
+          <did>
+            <unittitle>Account book of a merchant, who among other items, lists costs of various
+              voyages to Jamaica, Hamburg, and Lisbon for merchandise.</unittitle>
+            <unitdate datechar="creation" normal="1816-01-01/1816-12-28" type="inclusive">1816,
+              January 1-December 28 -</unitdate>
+            <physdesc id="aspace_b39cb829fd0b78044db27b3daf3c70d3">Autograph document 88 p. 34
+              cm.</physdesc>
+            <container id="aspace_8ebfd8b7a5005e79e1870a347cb78ea9" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_ac6e334acbb7037f556901d6c073077d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Also contains a Sermon preached at Red River, Ohio?, by Mr. Streightly, a
+                Dunkard; contract for the construction of a mill in Bloomington, Monroe County,
+                Indiana, September 6, 1816; and some arithmetic problems. Covering letter, signed by
+                H. C. Duncan, Sept. 28, 1905, states that this manuscript was obtained in 1884 by
+                the Rev. A. B. Philputt, pastor of the Christian Church of Bloomington, Ind., and
+                Henry L. Bates from James Borland, who resided southwest of Bloomington.</item>
+              <item>Includes transcription and provenance</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3b49c6baaead278bcb6c6ee00415fd50">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ef95760c7250c4bb2139a090b213f7f7" level="file">
+          <did>
+            <unittitle><persname>Dearborn, Benjamin, 1754-1838, musician.</persname> Boston,
+              Massachusetts. To Andrew Brimmer. "Our award on the subject submitted by yourself and
+              Mr. Hastings is ready to be delivered."</unittitle>
+            <unitdate datechar="creation" normal="1817-01-01/1817-01-01" type="inclusive">1817,
+              January 1 -</unitdate>
+            <physdesc id="aspace_6f5cc521162444e4d2a5f190ce1424ac">Autograph letter signed 1 p. 16
+              cm.</physdesc>
+            <container id="aspace_ce572cafc5307b5f6361b33594f1018f" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_0936f44230f685cf258a954ea57fd3a8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Letter also signed by Elisha Ticknor.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_68dd94572df07debcf7cdc52f40b84a4">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_444e23c6f4b804999bb859d366312904" level="file">
+          <did>
+            <unittitle><persname>Ticknor, Elisha, 1757-1821, educator, merchant.</persname> Boston,
+              MAssachusetts. To Andrew Brimmer. "Our award on the subject submitted by yourself and
+              Mr. Hastings is ready to be delivered."</unittitle>
+            <unitdate datechar="creation" normal="1817-01-01/1817-01-01" type="inclusive">1817,
+              January 1 -</unitdate>
+            <physdesc id="aspace_47e8a8b03e387cb5d3fb358b39da57bd">Autograph letter signed 1 p. 16
+              cm.</physdesc>
+            <container id="aspace_2403b013762f84fc0387e7b06a3d15f2" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_bcca3e1326fe7123299a45d43fda10dc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Letter also signed by Benjamin Dearborn.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_483cd52a2dbae00f9a2567d52d44461a">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b0ff6a9967c43549f0cceee9024ad480" level="file">
+          <did>
+            <unittitle><persname>Hall, Basil, 1788-1844, British naval officer.</persname> Calcutta,
+              India. To Sir Evan Nepean. Concerns documents relating to the Chinese Embassy which he
+              thinks will be of interest.</unittitle>
+            <unitdate datechar="creation" normal="1817-04-01/1817-04-01" type="inclusive">1817,
+              April 1 -</unitdate>
+            <physdesc id="aspace_737d34b32a9eda86c3dc0b296513ddce">Autograph letter signed 4 p. 25
+              cm.</physdesc>
+            <container id="aspace_062920338379783f54956fa9cd18293e" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_4dbc698f341d243777d8a544d6acc49a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Basil Hall, <title render="italic">Account of a voyage of discovery
+                  to the west coast of Corea.</title> London, 1818 (Lilly-Mendel DS895 .R6 H2 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2511ea91536383fc313fb5f3930adb75">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_04129e17279bd4b6cbc7c91d68daf836" level="file">
+          <did>
+            <unittitle><persname>Stuart de Rothesay, Elizabeth Margaret (Yorke) Stuart, baroness,
+                -1867.</persname> To Catherine Freeman (Yorke) Alexander, countess of Caledon.
+              Describes the death of Mme. Blanchart in a balloon accident.</unittitle>
+            <unitdate datechar="creation" normal="1819-07-06/1819-07-07" type="inclusive">1819, July
+              6 or 7 -</unitdate>
+            <physdesc id="aspace_0b1543316f87f24b2fba963b28ea0e46">Autograph letter signed 4 p. 23
+              cm.</physdesc>
+            <container id="aspace_02ad9df064a37ff54386b2197d9a17ed" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_c934aad983590ebfd9a8f1669ef988f9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Vincenzo Lunardi's <title render="italic">An account of the First
+                  Aerial Voyage in England...</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_de526169301612169fc8a347d104f25c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a24cbdf151c047723f44bf4d36198716" level="file">
+          <did>
+            <unittitle>Letter and document regarding l'Exposition des produites de l'Industrie
+              française au Louve.</unittitle>
+            <unitdate datechar="creation" normal="1819-09-10/1819-09-10" type="inclusive">1819,
+              September 10 -</unitdate>
+            <physdesc id="aspace_17af3f8ea21e16d44acbd3478ff05cbf">Autograph letter and
+              document</physdesc>
+            <container id="aspace_30dffa2ecd39afee623435f2589cd236" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_f7b6e9e3d46bef23e792d932fd0fc21e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by printed information about Christophe Philippe Oberkampf</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a193b25c1d415c61f23d836817541f95">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Sabbagh. France. <date normal="1992">1992.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8ec2a77e0977a4574137878d7b6e67b8" level="file">
+          <did>
+            <unittitle><persname>Hegel, Georg Wilhelm Friedrich, 1770-1831, philosopher.</persname>
+              Rechts-Philosophie und Politik.</unittitle>
+            <unitdate datechar="creation" normal="1819/1820" type="inclusive">1819-1820 -</unitdate>
+            <physdesc id="aspace_5a784bcb036ee3dfcf3625482ef8c181">Autograph document 2 604 2 p. 16
+              x 21 cm.</physdesc>
+            <container id="aspace_2510ebb79137047bc3bc00380e88061f" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_aab30c078c818768252e37935962e37d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Published: Hegel. Philosophie des Rechts: die Vorlesung von 1819/20 in einer
+                Nachschrift. Edited by Dieter Henrich. Frankfurt am Main, Suhrkamp, 1983 (Lilly
+                JC233 .H41 1983).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_85943009685392e0983b670a3925338d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from the Main Library. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e89b57abaab3567ae55c7f6b823c7d4d" level="file">
+          <did>
+            <unittitle>Assinato del Duque de Berry.</unittitle>
+            <unitdate datechar="creation" normal="1820-02-18/1820-02-21" type="inclusive">1820,
+              February 18-21 -</unitdate>
+            <physdesc id="aspace_2f78f9d07a439f3cd314ac5093952222">Autograph document 7 p. 30
+              cm.</physdesc>
+            <container id="aspace_83798577196b4e51acac2d0cd56c983a" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_95630e268b5ca5f9c28431aa62551c1b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In Spanish</item>
+              <item>Written at London</item>
+              <item>Report on the assassination of Duc de Berry, son of Charles X of France, with
+                reference to newspaper accounts</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_47cbda9634cd72bcebcb10fb4d501b27">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cb26f3ec3dbda0d947ca94f0ddf574c1" level="file">
+          <did>
+            <unittitle><persname>Delambre, Jean Baptiste Joseph, 1749-1822, astronomer.</persname>
+              Paris. To Joseph Nicolas Nicollet. Announces to Nicollet that he is to share half of
+              the Royal Academy of Sciences award for 1820 for his "grand travail" on the libration
+              of the moon with the German astronomer Johann Franz Encke for his observations of the
+              comet named for him at the public meeting on March 27.</unittitle>
+            <unitdate datechar="creation" normal="1820-03-24/1820-03-24" type="inclusive">1820,
+              March 24 -</unitdate>
+            <physdesc id="aspace_90d371dc418984106fbce19a8c7ed8a2">Autograph letter signed 2 p. 25
+              cm.</physdesc>
+            <container id="aspace_9f403418f6eeb1a3c1ccf413bd5d8c21" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_72e7eb4aedcac8fd46ab4fef4cdd39da">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+              <item>Written by a secretary but signed by Delambre.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9dfd20a47d619e663cd4d5cdc28965dd">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. Harper lot 12314. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cb327da7a728ed739158fc15b75ea257" level="file">
+          <did>
+            <unittitle><persname>Shepherd, James, naval officer.</persname> Log of Proceedings on
+              board the Albion of London kept by James Shepherd, commanded by William Wade West,
+              Esq., lieutenant Royal Navy, commencing with a 2nd voyage in October 1820, in three
+              parts.</unittitle>
+            <unitdate datechar="creation" normal="1820-10-07/1821-06-12" type="inclusive">1820,
+              October 7-1821, June 12 -</unitdate>
+            <physdesc id="aspace_b5078ea88590a57ba073812d07440eb4">Autograph document signed 146 p.
+              23 cm.</physdesc>
+            <container id="aspace_7cee7a244fc4a13f2f2aaab08dcc5a28" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_7897fc9e09f6eb76f0606b68f2cdeaec">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Contents: 1) Log of Proceedings...in three fragments, 1820, Oct. 23-Nov. 10, 16
+                p.; 1820, Nov. 13-Dec. 10, 28 p; 1821, Jan. 8-9, 18-19, 22-23, 6 p. Cover page gives
+                details of the ship's construction; 1820, Oct. 23, remarks on board; 1820, Oct.
+                29-1821, Jan. 23, ship's log of voyage from London to Mauritius, with concluding
+                remarks... "the sweet vurder [sic] from the plantation was very refreshing..." 2)
+                Remarks on board the Albion bound to the Mauritius, William Wade West, commander
+                October 7, 1820, bound in linen, 96 p. 1820, Oct. 22-1821, Jan. 23, journal of the
+                Albion from London to Mauritius, with concluding remarks..."the sweet verdure from
+                the plantations was very refreshing...," p. 1-21; 1821, Jan. 24-Mar. 20, journal of
+                the period at Port Louis during which the cargo of sugar with ownership markings was
+                loaded, the ship repaired with the help of black people, and on feb. 15 an incident
+                about the slave trade reported p. 22-30; 1821, Mar. 21-May 26, ship's log of voyage
+                from Mauritius to London, p. 31-96; p. for the entries of 1821, May 27-June 12 are
+                missing; the name of James Shepherd appears in the entry for Apr. 4, 1821. 3) Track
+                of the Albion form London to the Mauritius and return, William Wade West, commander,
+                1820-1821...completing a voyage of 23500 miles in seven months; outward bound voyage
+                shown in red; inward bound voyage shown in blue; continents outlined in green, red,
+                and blue; signed in lower left hand corner by James Shepherd, 1821, Port Louis.
+                Autograph map signed 1 leaf 45 x 39 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4c720f5c9d8f5909e0f2b1c8e6a8fd48">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southhampton Road, Ringwood Hants, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_35a1cc8e8e0c4aabd784144d1725f1d6" level="file">
+          <did>
+            <unittitle>Track of the Albion from London to the Mauritius and return</unittitle>
+            <unitdate datechar="creation" normal="1820-10-31/1821-06-12" type="inclusive">1820,
+              October 31-1821, June 12</unitdate>
+            <container id="aspace_7331d98a8a394da4380acc294954f092" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_80f05a56f9813be6c355bce15d7c2010" level="file">
+          <did>
+            <unittitle>Pankey, Charlotte H. Draft book. Pertains to weaving.</unittitle>
+            <unitdate datechar="creation" normal="1821-03-21/1821-03-21" type="inclusive">1821,
+              March 21 -</unitdate>
+            <physdesc id="aspace_2d39f22842dc24097d351484c37bf284">Autograph document signed 10 p.
+              10 x 20 cm.</physdesc>
+            <container id="aspace_2df620260a5edeb9ff403baa5bd7da55" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_637a6ea83db95cc35922332c22bc7fae">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Kelso, deceased, Linton, Indiana. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3949de24b2594f5311bdd1a3c904120e" level="file">
+          <did>
+            <unittitle>Hunter, Fanny Orby?. To King George IV. Invitation to dinner.</unittitle>
+            <unitdate datechar="creation" normal="1821-05-10/1821-05-10" type="inclusive">1821, May
+              10 -</unitdate>
+            <physdesc id="aspace_db7db311ccc1a5b7d5a971638fb61853">Autograph note signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_fe9e2653af3da6586dd420c14019a5fb" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_488d88639631fcd01c9107e3eeec6549">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_afb072b63ce68826df12767137a96d20" level="file">
+          <did>
+            <unittitle>Daybook of European merchant.</unittitle>
+            <unitdate datechar="creation" normal="1821-05-22/1830-12-30" type="inclusive">1821, May
+              22-1830, December 30 -</unitdate>
+            <physdesc id="aspace_54bf34969e0762adc9df3563c281d14c">Autograph document 68 p. 20
+              cm.</physdesc>
+            <container id="aspace_dd838221140901145c0d313e22f39524" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_4ec78ca239a3b6dce05813cbba68ebb9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in vellum boards</item>
+              <item>Records details of transactions including price paid in country of origin,
+                freightage, insurance, lighterage, commission, warehouse rent, brokerage, sales in
+                country of destination</item>
+              <item>Profit figure in red ink</item>
+              <item>Goods include: cotton, coffee, oranges, goat skins, gold, cork, almonds, copper,
+                calicoes, sugar, shank bones, baskets, butter</item>
+              <item>Places of origin and destination: Rouen, Lisbon, London, Antwerp, St.
+                Petersburg, Bahia, Rio, Trieste, Hamburg, Pernambuco</item>
+              <item>Remainder of volume used as scrapbook for clippings, some dated between
+                1866-1875</item>
+              <item>Bookplate of Sutton Sharpe, Hampstead</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_32c484b338082584bcbf98909796a98a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ringwood, Hants, England. <date normal="1981"
+              >1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5c62f936b8e73cfffa3b235de969f836" level="file">
+          <did>
+            <unittitle><persname>Offley, David, -1838, merchant.</persname> Smyrna, Turkey. To
+              Luther Bradish, Constantinople. Arrival and departure of vessels; protection of
+              American citizens at Smyrna.</unittitle>
+            <unitdate datechar="creation" normal="1821-10-02/1821-10-02" type="inclusive">1821,
+              October 2 -</unitdate>
+            <physdesc id="aspace_e76d30667a97ed0642405218cab8b954">Autograph letter signed 2 p. 25
+              cm.</physdesc>
+            <container id="aspace_93473ddc97dbdea025290b52310dc200" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_79d4847d937d54fc32857b0919e447a1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1946/1947" type="inclusive"
+                >1946-1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_da211ba560b544017f9399981301bd5b" level="file">
+          <did>
+            <unittitle>Royal Company of Archers. Edinburgh, Scotland. Certificate of admission
+              issued to Major I. Thompson of the 6th Regiment of Foot and signed by the secretary
+              John Linning.</unittitle>
+            <unitdate datechar="creation" normal="1823-05-13/1823-05-13" type="inclusive">1823, May
+              13 -</unitdate>
+            <physdesc id="aspace_7cda5b2466b41f5d541438f9adab57cc">Document signed 1 p. 35
+              cm.</physdesc>
+            <container id="aspace_06b2dcdd9b3d4ae7efdf0b785cfec281" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_684b1702a82bc1880699a2a66504e756">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Partly printed</item>
+              <item>Accompanied by red wax seal</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_45ecf7948b5dbdd984a8298ee55a0f26">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Clarence N. Hickman, 3536 79th Street, Jackson Heights, New York, 11372. <date
+                normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7098de96027b864d6d92d743ea1d294c" level="file">
+          <did>
+            <unittitle><persname>Mathews, Charles, 1776-1835, comedian.</persname> Stafford. To. T.
+              Speidell, St. John's College, Oxford. Plans to pass through Oxford and suggests
+              meeting for dinner.</unittitle>
+            <unitdate datechar="creation" normal="1823-07-13/1823-07-13" type="inclusive">1823, July
+              13 -</unitdate>
+            <physdesc id="aspace_6983f5b00a2ece0ef35b0118193fdadd">Autograph letter signed 3 p. 23
+              cm.</physdesc>
+            <container id="aspace_c1899028dc33fdec9bf6ce5765ed4e48" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_32e7bd48e127765133617e138ff7f526">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">Memoirs of Charles Mathews, comedian</title>
+                by Mrs. Mathews. London, Richard Bentley, 1838-1839 (Lilly PN2598 .M42 M42 Vol. I,
+                copy 1).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_881fa2634d9ef1fb9b63c22ba7f93823">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9664e61809d806be377b536eb0fcaab8" level="file">
+          <did>
+            <unittitle>Deane, C. Letter to Charles Benjamin Caldwell.</unittitle>
+            <unitdate datechar="creation" normal="1825-08-30/1825-08-30" type="inclusive">1825,
+              August 30 -</unitdate>
+            <physdesc id="aspace_44dd10ac79dc59937eedac0a87e15684">Autograph letter signed 1
+              p.</physdesc>
+            <container id="aspace_5c6ece7e3c39c0cb047c90cf25c06f8b" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_b46ccf31ef4ed71896216b8e6725c8f2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Jean Charles Thibault de Laveaux, <title render="italic">Nouveau
+                  dictionnaire de la langue française.</title> Paris, Deterville, 1820 (Lilly PC2625
+                .L3)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6a7fa6a7657b436c6868667caa9a90e8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ab56d0a495a915fd0a37dad35f5a98d3" level="file">
+          <did>
+            <unittitle>Nous soussignés certifions, que messieurs Coscia et Bruera sont des Italiens
+              émigrés par opinions liberales, et ont fait avec nous la dernière campagne
+              d'Espagne.</unittitle>
+            <unitdate datechar="creation" normal="1827-04-12/1827-04-12" type="inclusive">1827,
+              April 12 -</unitdate>
+            <physdesc id="aspace_085664db28593faa3c93b1dc0de8d401">Autograph document signed 1 leaf
+              22 cm.</physdesc>
+            <container id="aspace_95799c6059d479e0b65d2d88193a43fe" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_134078088a6f417d72b3168937073686">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed at London by four undercipherable signatures</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1bbc9faa95c55d733a53f2aa9a9104c4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_40b812a50df26c30268352db7bb002ed" level="file">
+          <did>
+            <unittitle><persname>Pope, R., 1748-?.</persname> Address to his servants.</unittitle>
+            <unitdate datechar="creation" normal="1827-12-02/1827-12-02" type="inclusive">1827,
+              December 2 -</unitdate>
+            <physdesc id="aspace_89104539f4d13843a136463bf88dd089">Autograph document signed 3 p. 23
+              cm.</physdesc>
+            <container id="aspace_732574edfa01e1bc9dcc3c149cf6b949" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_1a3515510ddd87a26dc64f55d876a43b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c3e60dd8e14891d9a5a564c164c4eb28" level="file">
+          <did>
+            <unittitle><persname>Rektei, A. D., translator.</persname> Tokyo, Japan. Collection of
+              letters translated from English into Dutch. Refer to a number of subject between 1777
+              and 1778.</unittitle>
+            <unitdate datechar="creation" normal="1828-08-27/1828-08-27" type="inclusive">1828,
+              August 27 -</unitdate>
+            <physdesc id="aspace_2269ce9804742f9a6ab6ec624e49aaec">Autograph document signed 68 p.
+              25 cm.</physdesc>
+            <container id="aspace_7d734ecd73b6f79accad4943f69a72d5" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_b5186fb17d475355dd9d7f0e0a7c460f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In ink</item>
+              <item>Title page in Japanese</item>
+              <item>Bound in a later brocaded binding in blue and silver, oversewn in oriental style
+                in a matching folder.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_bb436e4cdb261c72dc4e59bc8d2baeb4">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Charles Ralph Boxer, King's College, Strand, W. C. 2, London,
+              England. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_41e05be48a0ff18f6a87f7cd72ec9a2e" level="file">
+          <did>
+            <unittitle><persname>Mason, Thomas Monk, 1803-1889, aeronaut.</persname> The King's
+              Theatre. To "Sir." Explanation of engagement of Madame Lazise to appear in
+              operas.</unittitle>
+            <unitdate datechar="creation" normal="1830-04-21/1830-04-21" type="inclusive">1830,
+              April 21 -</unitdate>
+            <physdesc id="aspace_dae9cf7324574292bf5c39020b0781df">Autogrpah letter signed 2 p. 23
+              cm.</physdesc>
+            <container id="aspace_ecfdba513e3e5510ace35c7d2a7fe6cd" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_4b3e15d66fcdf13735eb5a8557517cc7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from T. M. Mason's <title render="italic">Aeronautica.</title> London,
+                1838 (Lilly TL544 .M4)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a6084ce57ac6bbff3a7ceaac276b16c8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Hollingsworth, dealer, London. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f278d80ad4062988decf9731b5d073e1" level="file">
+          <did>
+            <unittitle><persname>Wellington, Arthur Wellesley, 1st duke of, 1769-1852,
+                statesman.</persname> London. Note to Captain Clarke. "The Duke has received his
+              letter of the 1st instant, and begs that any application relative to the...Prize...may
+              be made in the proper official channel..."</unittitle>
+            <unitdate datechar="creation" normal="1830-09-02/1830-09-02" type="inclusive">1830,
+              September 2 -</unitdate>
+            <physdesc id="aspace_ee20fe40bb2f26de5cd122786bc75db9">Autograph note signed 2 p. 17
+              cm.</physdesc>
+            <container id="aspace_d770cf7a7de9bdd0f15457a164366bca" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_39a762b1a7735a90e3eeb73151c79e22">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Holograph note in third person in the hand of the Duke of Wellington</item>
+              <item>Removed from William Combe, <title render="italic">The wars of
+                  wellington,</title> London, printed by C. Whittingham, 1819 (Lilly PR3359 .C5
+                W28).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_06972c242ad36810c7b13633bc00948f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1975">1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b817bd04ca620a2c1bc5727387955536" level="file">
+          <did>
+            <unittitle><persname>Bowditch, Nathaniel, 1773-1838, mathematician,
+                astronomer.</persname> Receipt to Hilliard Grey &amp; Co. Receipt is for Bowditch's
+              greatest scientific work, his translation and editing of Laplace's <title
+                render="italic">Mécanique Céleste</title> of which Hilliard Grey had ordered four
+              copies of volume one, published in 1829.</unittitle>
+            <unitdate datechar="creation" normal="1832-05-09/1832-05-09" type="inclusive">1832, May
+              9 -</unitdate>
+            <physdesc id="aspace_d1aebd6d145aefcdea7361643decad69">Autograph document signed 8 x 20
+              cm.</physdesc>
+            <container id="aspace_eac7a3f89af3392fbdc4bcb00c5be4e8" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_d1e1da713bf6a5b692606a7c81f83a16">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>The four volume work is in the Lilly Library (Lilly QB351 .L312)</item>
+              <item>Includes portrait of Bowditch</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_24d8ceacc081f584eb7e1aeb7462cc3b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. H. P. Kraus, 16 East 46th Street, New York, N.Y. 10017. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_920b9cba5328b73feb2ff4d6e896f04d" level="file">
+          <did>
+            <unittitle><persname>Macaulay, Thomas Babington Macaulay, 1st baron, 1800-1859,
+                historian.</persname> London. To "Sir." Regrets press of engagements prevents him
+              from contributing to magazine.</unittitle>
+            <unitdate datechar="creation" normal="1832-07-04/1832-07-04" type="inclusive">1832, July
+              4 -</unitdate>
+            <physdesc id="aspace_c93ed88b331760c331985363e8ffe5d9">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_97fbe0f9f2e05830baebc78cc3cc7012" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_e7b623c95b2e32d173ce96254e762e03">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Macaulay's <title render="italic">Lays of ancient Rome,</title>
+                London, Longman, Brown, Green, and Longmans, 1892 (Lilly PR4963 .L42).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_5fd0be765bf2b2fae71d59d2a4f636f8">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_428bebb21359487f02e209d2d55ebc65" level="file">
+          <did>
+            <unittitle><persname>Cabet, Etienne, 1788-1856, political radical.</persname> To M.
+              Penaty, Chef de la Division de Paris. Change of address.</unittitle>
+            <unitdate datechar="creation" normal="1833-08-08/1833-08-08" type="inclusive">1833,
+              August 8 -</unitdate>
+            <physdesc id="aspace_3064e4ecbf6baa637ef0bb2e53264405">Autograph letter signed 1 p. 22
+              cm.</physdesc>
+            <container id="aspace_9c35f9277e46a30873818aa7ac30e3fc" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_5685eb0bca7e95a877f02ac53bd0bba8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Godspeed's Book Shop, 18 Beacon Street, Boston, Massachusetts. <date
+                normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1451d12eeed880c59601ea2427046997" level="file">
+          <did>
+            <unittitle><persname>Butts, R. G., fl. 1841, plantation owner.</persname> Journal and
+              memorandum book of plantation Thomas in British Guiana and travels in Great
+              Britain.</unittitle>
+            <unitdate datechar="creation" normal="1834-08/1841-02-06" type="inclusive">1834,
+              August-1841, February 6 -</unitdate>
+            <physdesc id="aspace_0173e3c74c3b9b5d4f022185ab59a3e2">Autograph document signed 78 p.
+              12 x 18 cm.</physdesc>
+            <container id="aspace_8177a2275b500bbda2c3da8c71c615ec" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_756872e0afda3bf9b372ed3241298b68">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Thirty-two blank pages of a total of 110 p.</item>
+              <item>Boards with clasp</item>
+              <item>First thirty-two pages, June 12, 1835-Dec. 27, 1837, are accounts of several
+                trips to the United Kingdom in which he describes his social life, journeys,
+                dinners, theaters, opera, othersocial engagements, and visits with his sisters, one
+                of whom took care of his two sons.</item>
+              <item>The first journey was made on the ocean going ship "Johnstone" which left
+                Demerara on June 12, 1835, for Liverpool arriving in Ireland on July 27 and by means
+                of a fishing boat landed him at Galley Head.</item>
+              <item>On Aug. 30, 1835, he left for Madeira where he had friends and business
+                acquaintances in connection with the emigration of labor to his and his friends'
+                plantations in Demerara (now Georgetown) British Guiana. He departed for London on
+                November 11, 1835, in the brig "Dart" and arrived at his destination nineteen days
+                later.</item>
+              <item>On Dec. 21, 1835, he rented Brookfield House at Teignmouth, Devon.</item>
+              <item>A party of nineteen, which included his sistersr and his sons, embarked on Apr.
+                9, 1836 on board the barque "Usk" at Torquay for Quebec.</item>
+              <item>On Aug. 1, 1836, he purchased Mr. Stewart's undivided half of the plantation
+                Arcadia and he notes in some detail the financial arrangements.</item>
+              <item>He departed for Demerara on Apr. 5, 1837, in the barque "Nautilius" and arrived
+                there on May 3.</item>
+              <item>Jan. 27, 1841, he left Demerara on a political mission at the request of members
+                of the court in the "Eliza Miller" steamer for Trinidad--returned Feb. 6 "having
+                satisfactorily arranged in it Sir Hy MacLeod the Governor of Trinidad."</item>
+              <item>Between 1834 and 1841 numberous memorandums were made on a variety of subject
+                which included finances, a scale of food allowances for one hundred men on a voyage
+                from Madeira for about twenty-five days.</item>
+              <item>Since slavery was terminated in British possessions on Aug. 1, 1834, Butts noted
+                large sums due him in compensation and described the method of arriving at it--"Mode
+                and manner of the Appraisement of Negroes of British Guiana August 1834." Applying
+                these principles, he then gives a detailed appraisement of plantation Thomas.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_900c7dd842201ca596f1511f2f9e773a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Tingwood, Hants, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b27b7129c8226198d46b475715b1f56a" level="file">
+          <did>
+            <unittitle><persname>Bertie, Henry, fl. 1835.</persname> Journal of an European tour.
+              The tour commences in Naples and progresses through Amalfi, Rome, Genoa, Turin,
+              Geneva, Lucerne, Fribourg, Heidelberg, Bonn, Cologne, Aix la Chapelle, Paris, Basle,
+              Zurich, Como, Milan, Parma, Modena, Rimini, from which he sails through the Adriatic
+              to Corfu, and through the Gulf of Corinth to Athens, where the journal
+              ends.</unittitle>
+            <unitdate datechar="creation" normal="1834-11-26/1835-07-10" type="inclusive">1834,
+              November 26-1835, July 10 -</unitdate>
+            <physdesc id="aspace_daebb5d18873150a1fe7078bb901aee7">Autograph document 132 p. 24
+              cm.</physdesc>
+            <container id="aspace_7acece77fb163920bc01cdd233805c40" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_391035beebadb3914a9ffe8d9493d635">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>There are sixteen sketches, maps, plans, and smaller diagrams in the
+                text.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b357b667015523fc60138b30d6b2a690">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ltd., Ringwood, Hants, England. <date normal="1974"
+                >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_dfa4fccf7780335f4d4d3ea7100abe62" level="file">
+          <did>
+            <unittitle><persname>Smirke, Sydney, 1798-1877, architect.</persname> 12 Regent Street,
+              London. To Richard Prall, Rochester, Kent, England. Appends the "reduced plan" for the
+              Medway Bathing Establishment at an estimated cost of L2600.</unittitle>
+            <unitdate datechar="creation" normal="1835-05-27/1835-05-27" type="inclusive">1835, May
+              27 -</unitdate>
+            <physdesc id="aspace_76191e969c885c6602d43764a25e0749">Autograph letter signed 3 p. 31
+              cm.</physdesc>
+            <container id="aspace_c609e860e6c3fd6ebbeff676df0b6dd7" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_67e3ed6599a647ff05a1ca4c27a381b4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Plan of the building in pen and ink and wash on the attached sheet</item>
+              <item>Paper watermarked J. Simmons 1824</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_75b71cefdef72f934052d83c3f47fa1c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Paul Grinke, 38 Devonshire Place, London. <date normal="1974"
+              >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_db9e7d26cfd7ffa3a94ed738bd1d8363" level="file">
+          <did>
+            <unittitle><persname>Merle d'Aubigne, Jean Henri, 1794-1872, theologian.</persname> To
+              DeClercq, W., directeur de la Société de Commerce des Pays-bas, Amsterdam. Recommends
+              Mr. Sprague, Presbyterian pastor of Albany, America, and comments on the
+              lithography.</unittitle>
+            <unitdate datechar="creation" normal="1836-01-20/1836-01-20" type="inclusive">1836,
+              January 20? -</unitdate>
+            <physdesc id="aspace_7157d01c30c5a81b79d70b88ed7b3f3a">Autograph letter signed 3 p. 21
+              cm.</physdesc>
+            <container id="aspace_2a26096f613acf61e291fea0b73a60ab" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_147d18de626b25e5cdd06144fd7e2687">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Letterhead has a lithograph of a tombstone standing among some trees with the
+                name steiger, IX Janv. MDCCCXXXVI and below the lithograph the words Le juste est
+                mort!...Soyons-y attentifs. Esaie lvii, 1</item>
+              <item>French</item>
+              <item>Accompanied by picture of Merle d'Aubigne</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_62414ccaaddef3242ba79eaa46df39be">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4ce55cbbbd6d0e49b165f1beed060bf8" level="file">
+          <did>
+            <unittitle><persname>Smith, William Henry, fl. 1840.</persname> Arithmetic.</unittitle>
+            <unitdate datechar="creation" normal="1836-02-29/1840-02-15" type="inclusive">1836,
+              February 29-1840, February 15 -</unitdate>
+            <physdesc id="aspace_4bc8824de843d1fadbe7e6fef031afa7">Autograph document signed 336 p.
+              33 cm.</physdesc>
+            <container id="aspace_b72e0a9c4012f32400a4391f8de81018" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_8a3db49cc75659b874a51e0cf329d7b2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Transferred from Swain Hall Library, Indiana University, Bloomington, Indiana,
+                October 21, 1969.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_14ea598ba1181fd9302d53267289b309">
+            <head>Immediate Source of Acquisition</head>
+            <p>Received by the Main Library on August 16, 1909 and cataloged on November 19, 1909 by
+              "A.B.G."</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d7512667f9b8cd3e9f40425ff5622bd7" level="file">
+          <did>
+            <unittitle>Taylor, Georgiana Jane, et. al. Journal.</unittitle>
+            <unitdate datechar="creation" normal="1836-10-17/1843-08-29" type="inclusive">1836,
+              October 17-1843, August 29 -</unitdate>
+            <physdesc id="aspace_34214364486774f9694c38f2b2d2045e">Autograph document 86 p. 18
+              cm.</physdesc>
+            <container id="aspace_047e0ff6befcff284e892c08e390a247" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_3a36e09c833c1afcfa362be26aa900d9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in half-black straight-grained morocco</item>
+              <item>Back cover with several faces drawn in</item>
+              <item>Contents: 1) 1836, Oct. 17-1837, Apr. 13, by Georgy Taylor, daughter of Thomas
+                William Taylor, 1782-1854, lieutenant-governor of Sandhurst; 2) 1841, Aug.1-Dec.25,
+                by a sister of Georgy Taylor; 3) 1843, Aug.1-29, by a sister of Georgy Taylor; 4)
+                1877, Feb. 11, Paris, Comment of concern about three letters, in English and French,
+                in pen and pencil, by an unidentified writer</item>
+              <item>Mention throughout of daily visitors and visiting; of walking "along the tow
+                path"; of brother Reynell George Taylor, 1822-1886, general; of sister Annie's
+                wedding and later sitting for a portrait by Rochard; the visit in August of 1843 of
+                Georgy and Mr. Barnard</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_fe6c90ab2464bcf09b0e582c7911a3db">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristol, Ringwood, Hants, England. <date normal="1981"
+              >1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6ac2df5585de5714e6b352ee2f7796fd" level="file">
+          <did>
+            <unittitle>Garrett, Mrs. Mary Ann. Autograph book.</unittitle>
+            <unitdate datechar="creation" normal="1827-06-12/1835-01-01" type="inclusive">1827, June
+              12-1835, January 1 -</unitdate>
+            <physdesc id="aspace_e0024c35cd6a6f865e7c5eb0214bfef4">Autograph document 56 p. 12
+              cm.</physdesc>
+            <container id="aspace_15dc402730df8f91c498db8fc9d5a411" label="box" type="box"
+              >4</container>
+          </did>
+          <acqinfo id="aspace_ad73f9464f5e324e68d24205046217de">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Frank Wilson, dealer, Boston, Massachusetts. <date normal="1961"
+                >1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_2943fe538d05ffd09cf4586f2f7be897" level="file">
+          <did>
+            <unittitle>Mihayel, Ter. To Armenian Communitie</unittitle>
+            <unitdate datechar="creation" normal="1836-02-15/1836-02-15">1836, February
+              15</unitdate>
+            <container id="aspace_4b09e9e9b151c26106ea6c7276d145fc" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 audience="internal" id="aspace_6f72987fc8dcc618956d25373f27432c" level="file">
+          <did>
+            <unittitle>Waybill for Independent Coach... </unittitle>
+            <unitdate datechar="creation" normal="1837-09-25/1837-09-25">1837, September
+              25</unitdate>
+            <container id="aspace_071cb9cc48274124efd6c07cf51769e7" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_83253edd21ac824e4e9c18bc308b79e9" level="file">
+          <did>
+            <unittitle><persname>Waterman, James, 1819- , footman.</persname> Autobiography. An
+              interesting and amusing autobiography of an English servant. Written in the third
+              person.</unittitle>
+            <unitdate datechar="creation" normal="1837/1843" type="inclusive">1837-1843 -</unitdate>
+            <physdesc id="aspace_9161504b4490493762ebb4736a84b71b">Autograph document 176 p. 20
+              cm.</physdesc>
+            <container id="aspace_75a46ffe4d13fc244fea612f2747346a" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_e34b47e663929c50bcd3a87d831ba93a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In ink</item>
+              <item>Bound</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_79bec44cf92aa5a5c9554acbb0d2d6e3">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_32f7458dd6e5150d77b4108752340240" level="file">
+          <did>
+            <unittitle><persname>Crosse, Andrew, 1784-1855, electrician.</persname> Broomfield. To
+              John Peter Gassiot, Clapham Commons, London. "I am still proceeding with my
+              experiments as vigorously as ever. The more I examine electrical operations, the more
+              I am convinced how much we have to learn." He goes on to give the specifics of some of
+              his experiments.</unittitle>
+            <unitdate datechar="creation" normal="1839-02-06/1839-02-06" type="inclusive">1839,
+              February 6 -</unitdate>
+            <physdesc id="aspace_4843806e013c5ac806ac2e36e39e9275">Autograph letter signed 4 p. 23
+              cm.</physdesc>
+            <container id="aspace_a5491c44ceb12806e4646b6e22f79653" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_5c7dd9848fa11bcef7eea1e221dfa1c1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Portion of red seal remaining</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_998035ac7d9cab169f4c08eb258e76d7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ringwood, Hants, England. <date normal="1975"
+              >1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_14d0e2722fd5cc0bbe166ea974d742b8" level="file">
+          <did>
+            <unittitle>Bowden, Temple, fl. 1842. Short journal. Relates to journeys in Europe giving
+              times of departure and arrival from and to towns in France, Italy, and Switzerland,
+              names of inns and remarks on accommodations.</unittitle>
+            <unitdate datechar="creation" normal="1839-05-16/1841-10-23" type="inclusive">1839, May
+              16-1841, October 23 -</unitdate>
+            <physdesc id="aspace_22040c46c1d8b2ad0ff964b3a65ff8c0">Autograph document 54 p. 10
+              cm.</physdesc>
+            <container id="aspace_4803d6af4cfe90b0d9a20e8039595eb3" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_79ec3dd26ca2c978c7b77b4e76d028fb">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in with short journal is a brief journal by Kate Browning, Lucy Browning,
+                and G. K. Dansey. Autograph document 12 p. 10 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0c73a432cecabc9ffa95f17bf6a14dea">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ltd., Ringwood, Hants, England. <date normal="1974"
+                >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a549c3e42f9255c372815d1bc9c9569b" level="file">
+          <did>
+            <unittitle><persname>Owen, Robert, 1771-1858, social reformer.</persname> To William
+              Johnson Fox, Chronicle office, Strand. Shorthand letter.</unittitle>
+            <unitdate datechar="creation" normal="1840-03-02/1840-03-02" type="inclusive">1840,
+              March 2 -</unitdate>
+            <physdesc id="aspace_d535d2576bb43a0ce22162487c5f9fb4">Autograph letter 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_6c2f71a412265644da469b8717a67bfb" label="box" type="box"
+              >4</container>
+          </did>
+          <scopecontent id="aspace_8870558247541b75d9bbb6c1065217af">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_281f38771f2baf94acf4120e97170d3e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Hamill &amp; Barker, 230 North Michigan Avenue, Chicago, Illinois. <date
+                normal="1960">1960.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4bd2adeb577578af49b9f0b72a46a083" level="file">
+          <did>
+            <unittitle>Dutch-Japanese dictionary.</unittitle>
+            <unitdate datechar="creation" normal="1840/1840" type="inclusive">Ca. 1840 -</unitdate>
+            <physdesc id="aspace_270cdb8825a8eea743623d6fe324679b">Autograph document 1090 p. 21 x
+              29 cm.</physdesc>
+            <container id="aspace_8e776b1aa09b51439bd9791dd80a62c8" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_1c7c9cba7fd68e19227629e3cd196ce4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In ink</item>
+              <item>Contemporary calf binding with stamped design of birds and foliage.</item>
+              <item>Mounted on the inside front cover is C. R. Boxer's bookplate</item>
+              <item>Japanese colored print of European soldiers, probably Dutch, tipped in on front
+                fly leaf.</item>
+              <item>Colored picture of Sakuma Shozan on a white horse by Shuho Ikegami from a
+                Japanese magazine is mounted on inside back cover.</item>
+              <item>On the last page of the text are two red seals. Dr. Boxer's is the smaller
+                seal.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e1c49f9ac0ae5b471758edbbca2a94ea">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Charles Ralph Boxer, King's College, Strand, W.C.2, London,
+              England. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_77cb9ba594ecbacacb51745131ad090f" level="file">
+          <did>
+            <unittitle>Shekleton, Alan. Dundalk, Ireland. To William Parkinson Ruxton, Esq.
+              Redhouse, Ardee, Ireland. Has made arrangements to send his plumber, "a very well
+              conducted man...&amp; a good tradesman" on a jaunting car, who just go on to
+              Arthurstown.</unittitle>
+            <unitdate datechar="creation" normal="1841-01-09/1841-01-09" type="inclusive">1841,
+              January 9 -</unitdate>
+            <physdesc id="aspace_263a85f0f43f6e91fc61e5da03692727">Autograph letter signed 1 p. 18.6
+              cm.</physdesc>
+            <container id="aspace_068ab6d9536f9c1a895716e9e9bd28f4" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_b06e1262b415b24b11537e8c4b3f8688">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from David Erskine Baker, <title render="italic">Biographia
+                  dramatica...</title> a new edition. Dublin, Printed by T. Henshall, 1783 (Lilly
+                Z2014 .D7 B2 1782a), vol. 2, which has bookplate of William Parkinson Ruxton.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ee2329da1213e95837bc932e6da30379">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1983">1983.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_939914ddf6e48c52bac216514ea61af2" level="file">
+          <did>
+            <unittitle>Owen, Robert, 1771-1858, social reformer. London. To John Finch. Comments on
+              Finch's <title render="italic">A Reformed Established Church the Best Means of
+                Obtaining Mental and Religious Liberty...</title> (Liverpool, 1841).</unittitle>
+            <unitdate datechar="creation" normal="1841-04-14/1841-04-14" type="inclusive">1841,
+              April 14 -</unitdate>
+            <physdesc id="aspace_c48f9aa414b7686117db9fca37160e7c">Autograph letter signed 1 p. 22
+              cm.</physdesc>
+            <container id="aspace_54c7c3fbbf60c4c59635c03e49c4d4b0" label="box" type="box"
+              >5</container>
+          </did>
+          <acqinfo id="aspace_6f5e48b7d3b0b857f9c42f8c5e97a5dc">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Hamill &amp; Barker, 230 North Michigan Avenue, Chicago, Illinois. <date
+                normal="1959">1959</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e6845c73cc4fc1aa35c2bcb99d8d73d3" level="file">
+          <did>
+            <unittitle>Dickson, Elizabeth, Chicacole, India. To Jane Ward, Madura, India. Asks her
+              opinion on the Millennium and then states that the Karens are so much easier convinced
+              than the Burmese.</unittitle>
+            <unitdate datechar="creation" normal="1841-06-08/1841-06-08" type="inclusive">1841, June
+              8 -</unitdate>
+            <physdesc id="aspace_a31ea043f494e7cf4f89047a005dc083">Autograph letter signed 4 p. 22
+              cm.</physdesc>
+            <container id="aspace_4b5f97e4ba20d6278efe6714646f7834" label="box" type="box"
+              >5</container>
+          </did>
+          <acqinfo id="aspace_671708b23405e84926d587731644c380">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source of purchase by Lathrop C. Harper, 8 West 40th Street, New York, New York,
+              10018, unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9bfc686e211509bc64c6d9c212071ab9" level="file">
+          <did>
+            <unittitle>Ingram, William, of Deptford, England. Autograph album.</unittitle>
+            <unitdate datechar="creation" normal="1841-09/1841-09" type="inclusive">1841, September
+              -</unitdate>
+            <physdesc id="aspace_b5ef57a453303d3f31b52d71e8970b9f">Autograph 36 p. 16 cm.</physdesc>
+            <container id="aspace_ff10a1f97b4260feb6cd66668e1a2bb8" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_6eacfdcec9613a100a72f0db002bfdd9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Glued into half morocco covers</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_00b11c283b77d097a43b0e3d08ddfa32">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_23d7fbb9bc0e2d1b92e8b9f80ef9311f" level="file">
+          <did>
+            <unittitle><persname>Meyrick, Sir Samuel Rush, 1783-1848, antiquary.</persname> Goodrich
+              Court. To Antonio Carlo Napoleone Mariotti [sic] Gallenga, 59 Devonshire Street,
+              Portland Place, London. "The uncertainty about the painter of the Tournament, which is
+              more curious than good, still continues...I want some books on Italian heraldry very
+              much."</unittitle>
+            <unitdate datechar="creation" normal="1841-10-18/1841-10-18" type="inclusive">1841,
+              October 18 -</unitdate>
+            <physdesc id="aspace_7df060255f05341f26c44f35a582018e">Autograph letter</physdesc>
+            <container id="aspace_2855de2cd3f150c260b4075284e1a5c8" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_d2b0c1b5416ee27dcc5551a5e6a7ef9b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mariotti was a fictitious name used to conceal Gallenga's identity</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_560f95805d56cb1bb18d5d13ae9257f4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York. <date normal="1967"
+                >1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_634082a64f1cd395898a9088900979a2" level="file">
+          <did>
+            <unittitle>Burnouf, Eugene. "Leçons de Grammaire Generale."</unittitle>
+            <unitdate datechar="creation" normal="1841/1841" type="inclusive">1841 -</unitdate>
+            <physdesc id="aspace_b5cd2c340c1c409b2bde5ed138c87390">Autograph document 300
+              p.</physdesc>
+            <container id="aspace_628ff2f36bef9c7fdaa4de22d860f5f5" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_19b4e3d35490ab92ef86a9740f11e304">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Unpublished manuscript that outlines Burnouf's principles for his
+                lectures</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_87c1418e4b3aec1b1e34be7c166e73fb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Colin &amp; Charlotte Franklin. Home Farm, Culham, Oxford, OX14 4NA. <date
+                normal="1998">1998.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ac16911b350a8faf8b1b3d502fc0e8f6" level="file">
+          <did>
+            <unittitle>Journal of "A few weeks on the Continent." Describes a tour by rail and
+              steamer through Holland, Germany, and Switzerland, returning via Paris.</unittitle>
+            <unitdate datechar="creation" normal="1842-06-02/1842-07-23" type="inclusive">1842, June
+              2-July 23 -</unitdate>
+            <physdesc id="aspace_6598bf93eb7da77c2924dad506d5d2ff">Autograph document 84 p. 18
+              cm.</physdesc>
+            <container id="aspace_a5e4a550d799f5a2b1b1f26138d4180e" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_ba0458dfc6402ec27ad809651ae9359d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in is a Journal of "The Midsummer vacation in England," June 19-July 21,
+                1843. Autograph document 28 p. 18 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_135da44e9c977984ba87428c1e2ce089">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ltd., Ringwood, Hants, England. <date normal="1974"
+                >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_240fcdd4838629230992302f5ffcb622" level="file">
+          <did>
+            <unittitle><persname>Liebig, Justus von, baron, 1803-1873, chemist. Giessen. To Michael
+                Faraday. Comments on his recent visit to Faraday and the scientific meeting at York;
+                contrasts the perception of science as found in England and in
+              Germany.</persname></unittitle>
+            <unitdate datechar="creation" normal="1842-12-19/1842-12-19" type="inclusive">1842,
+              December 19 -</unitdate>
+            <physdesc id="aspace_12362fc6e68ec3f8b9e864c170d51c62">Autograph letter signed 6 p. 24
+              cm.</physdesc>
+            <container id="aspace_e49ebf66f945d9db89bffbacc22080f5" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_5d8b17a8cdf4feea5827350ba6ff9a5b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by correspondence related to the conservation and repair of the
+                letter, 1952-1953; by a letter from George Wilhelm Merck to Josiah Kirby Lilly, Mar.
+                4, 1953, about the Liebig letter; by a copy of <title render="italic">The Lilly
+                  Review,</title> Nov. 1952, in which the Liebig letter is published</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c57438ca9cb922ddbaa4bcfc902da6db">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Lilly Research Laboratories Library, Indianapolis, Indiana. <date normal="1981"
+                >1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5038f25203ca8364272e3529eee7cd21" level="file">
+          <did>
+            <unittitle><persname>Wright, Thomas, 1810-1877, antiquary.</persname> 18 Gilbert Street,
+              Grosvenor Square, London, England. To John Gough Nichols. Proof of "my last sheet of
+              monasteries;" "figure of St. Christopher carrying a child with three
+              heads."</unittitle>
+            <unitdate datechar="creation" normal="1843-03-06/1843-03-06" type="inclusive">1843,
+              March 6 -</unitdate>
+            <physdesc id="aspace_ea6cb2cfe722ef7d53069555ffc8b6de">Autograph letter signed 1 p. 16
+              cm.</physdesc>
+            <container id="aspace_28bf620595abbd0c4afdf8a892fad12d" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_8f2c85f008fa1b10163b4cd5e82406d3">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Thomas Wright, <title render="italic">Anecdota literaria...</title>
+                London, John Russell Smith, 1844 (Lilly PR1203 .W7).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cfb51e49d425fd223cd09e7292b8bbc1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1952">1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_13692068cad42274c41f897bb022d34d" level="file">
+          <did>
+            <unittitle><persname>Trelawny, Edward John, 1792-1881, sailor,
+              adventurer.</persname>Putney Hill. To John Arthur Roebuck. Raymond Buildings. Concerns
+              some pictures which are for sale and makes comments upon them.</unittitle>
+            <unitdate datechar="creation" normal="1846-04-30/1846-04-30" type="inclusive">1846,
+              April 30 -</unitdate>
+            <physdesc id="aspace_3457a394e2ab0afa1a63b2d51eae089b">Autograph letter signed 3 p. 19
+              cm.</physdesc>
+            <container id="aspace_e4ab878db6b79e68669d2b42529fe7fa" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_851e5a92d882b29dd9998178ffad7fc6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_80213c64544469dcab49ee5616776a8c">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_af8d5acf486e7509d7d9bd4d9038fdad" level="file">
+          <did>
+            <unittitle><persname>Mathews, Anne (Jackson), 1782?-1869, actress.</persname> To Thomas
+              Potter Cooke. Thanking him for his portrait.</unittitle>
+            <unitdate datechar="creation" normal="1847-09-25/1847-09-25" type="inclusive">1847,
+              September 25 -</unitdate>
+            <physdesc id="aspace_1e39c249b2e867651d7d0d5f9288e904">Autograph letter signed 3 p. 18
+              cm.</physdesc>
+            <container id="aspace_bdeda0126967cb5f96759f382e81f057" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_0cd37a058a87a926b340c80596514e9d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by an engraving of Charles Mathews.</item>
+              <item>Removed from Mrs. Mathews, <title render="italic">Tea-table Talk.</title>
+                London, 1857.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ece0b1822f4304c01b84cfb1f6ffb411">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e1f445fb005275d032d4a7fd548ec594" level="file">
+          <did>
+            <unittitle>Thomas, Sarah Mary Anne, of Fairfod, Gloucester, England. Autograph
+              album.</unittitle>
+            <unitdate datechar="creation" normal="1848-10-20/1893-10-25" type="inclusive">1848,
+              October 20-1893, October 25 -</unitdate>
+            <physdesc id="aspace_fe0153c9b9acaa92f02e61f462016111">Autoraph 52 p. 18 cm.</physdesc>
+            <container id="aspace_79fb14c5d97a182fa79563de3d15039f" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_c31f7f10eb4fe68622ba9124f1f8d7c7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in black morocco</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9805d656f76d0af8432e37f0e9a0e005">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8b71bacb1b3b0e82912004c7f4bf4bd9" level="file">
+          <did>
+            <unittitle>Skeet, Charles J., London, England. To Lindsay &amp; Blakiston, publishers,
+              Philadelphia, Pa. Concerns their order for books and plates.</unittitle>
+            <unitdate datechar="creation" normal="1849-05-11/1849-05-11" type="inclusive">1849, May
+              11 -</unitdate>
+            <physdesc id="aspace_8bfbfe686a063829dcfff2f81976459e">Autograph letter signed 3 p. 23
+              cm.</physdesc>
+            <container id="aspace_7ce8bf7c4407281cef05567135e0d549" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_88726a1942a8626c0d743a998403ef61">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes provenance letter from Socony-Vaccuum Oil Company to Dr. F. C. Mathers
+                about manuscript and markings</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f74484477156d4e117dac00f8943301f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Deloss Grant, Socony-Vaccuum Oil Company, Chicago, Illinois. <date
+                normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e6965e5d4fc51865958e5c3d7c89294c" level="file">
+          <did>
+            <unittitle><persname>Mathews, Charles James, 1803-1878, actor.</persname> Lyceum. To
+              "Dear Sir." "Opinions are free but facts can only be misrepresented
+              intentionally."</unittitle>
+            <unitdate datechar="creation" normal="1849-10-02/1849-10-02" type="inclusive">1849,
+              October 2 -</unitdate>
+            <physdesc id="aspace_cb90d255bc76661013ba63d3975a0459">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_87942c73b31726c49a75eae9262d0389" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_010adbb9f9ffbb045a9f27b1f9c1f0a7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Mrs. Mathews, <title render="italic">Tea-table Talk.</title>
+                London, 1857.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9c9e57069aa6e5e32c7fad1629d1c5d9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_547d0186d670d65a6d38b102c3058e66" level="file">
+          <did>
+            <unittitle><persname>Hampton, John, 1799?-1871, aeronaut.</persname> Dublin, Ireland. To
+              William Henry Adams, London, England. Has sent the <title render="italic">Dublin
+                Freeman</title> and asks for a London or other paper containing Sir John Franklin's
+              plan.</unittitle>
+            <unitdate datechar="creation" normal="1849-11-17/1849-11-17" type="inclusive">1847,
+              November 17 -</unitdate>
+            <physdesc id="aspace_7dcd1e46a4132e9fd03c69ddba7acd84">Autograph letter signed 2 p. 19
+              cm.</physdesc>
+            <container id="aspace_b2b4b96f3f98ab51e2d06ab06ce5b05b" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_b81475d8f25769ad15183afc99487304">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Vincenzo Lunardi's <title render="italic">An Account of the First
+                  Aerial Voyage in England.</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2efc37856ec3d68a7208ad7153688974">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_be047bc5d9442df14184882965afbf3b" level="file">
+          <did>
+            <unittitle>MAcaulay, Thomas Babington Macaulay, 1st baron, 1800-1859, historian. F3
+              Albany, Piccadilly, London, England. To "Sir." Calls attention to his new
+              address.</unittitle>
+            <unitdate datechar="creation" normal="1850-03-03/1850-03-03" type="inclusive">1850,
+              March 3 -</unitdate>
+            <physdesc id="aspace_91fbe9da1363a204173caa8c7f351214">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_d210bfacd57fbd6451fd83d7485b6858" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_afed6a61c3c397ae5dfaee89c479e677">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Macaulay's <title render="italic">History of England...</title>
+                London, Longman, Brown, Gren, and Longmans, 1849-1861 (Lilly DA435 .M14).</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7adc0894e7e74738a5dc2709ad599ccc">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_01131b5e01476c2fa42c1b2e65ed9ad8" level="file">
+          <did>
+            <unittitle><persname>Playfair, Lyon Playfair, 1st baron, 1818-1898,
+                commissioner.</persname> Great Exhibition of the Works of Industry of all Nations,
+              1851...Exhibition Building, Kensington Road, London. To Mr. Gomlie, Esq., Glasgow.
+              Encloses proof for Gomlie's correction of classification XI and requests he add the
+              names of towns which could be consulted for recommendations of jurors.</unittitle>
+            <unitdate datechar="creation" normal="1851-01-29/1851-01-29" type="inclusive">1851,
+              January 29 -</unitdate>
+            <physdesc id="aspace_2f75cd90dc339024ba2538f6f96e3693">Letter signed 2 p. 20.5
+              cm.</physdesc>
+            <container id="aspace_ee7a417eb5d99d7bd7dd4b7fda7e8276" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_3814d9673090337f6f6a3689812d39de">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Enclosure not present</item>
+              <item>Letter in hand of secretary</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c39b6d0bb9c254403237f2aab44ec71d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. G. Sabbagh, Paris. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_220e965a635bd1d920ebc52ca277bfe7" level="file">
+          <did>
+            <unittitle><persname>Pugin, Augustus Welby Northmore, 1812-1852, architect.</persname>
+              Beverley. To J. T. Machell, Beverley. Emblem of Saint Matthew or Saint
+              Thomas.</unittitle>
+            <unitdate datechar="creation" normal="1851-02/1851-02" type="inclusive">1851, February
+              -</unitdate>
+            <physdesc id="aspace_82e5a2cf24ece6105425f4c5aa72462a">Autograph letter signed 2 p. 20
+              cm.</physdesc>
+            <container id="aspace_4a9f052c600a1cb3a74d214f38f0e6c8" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_084de5c4bc9025026626a4944328d091">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Mounted in Pugin's <title render="italic">The True Principles of Pointed or
+                  Christian Architecture...</title> London, Henry G. Bohn, 1853.</item>
+              <item>Photocopy present in Miscellaneous mss.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_def752893e7e12731906ac9668f9071e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1958">1958.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_202470c5e72bc855515d940e80795bf1" level="file">
+          <did>
+            <unittitle><persname>Mathews, Charles James, 1803-1878, actor.</persname> Lyceum. To "My
+              dear Sir." Relates to newspaper publicity.</unittitle>
+            <unitdate datechar="creation" normal="1851-03-22/1851-03-22" type="inclusive">1851,
+              March 22 -</unitdate>
+            <physdesc id="aspace_477c726232a6f73e2f0de13d4a662b67">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_b9d1447bde69c0c41e4de5b834673e76" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_769595bbbd9f03f2a817e8385028c480">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Mrs. Mathews, <title render="italic">Tea-table Talk.</title>
+                London, 1857.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2061f7de83efb69bb4317038db2911dc">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7eaee7da111c6a562f1e4f57d9db849c" level="file">
+          <did>
+            <unittitle><persname>Forster, John, 1812-1876, biographer, dramatic critic.</persname>
+              58 Lincoln's Inn Fields, England. To Richard Robert Madden. Concerns obligation of his
+              correspondent to send forward certain sheets of his announced book for criticism
+              before publication.</unittitle>
+            <unitdate datechar="creation" normal="1854-08-18/1854-08-18" type="inclusive">1854,
+              August 18 -</unitdate>
+            <physdesc id="aspace_5f30dff16e26d3a8b7b498bca1b7d37d">Autograph letter signed 4 p. 11
+              cm.</physdesc>
+            <container id="aspace_b7d3fe2ac8952fb346a9159c24de911a" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_519d55b6d4ebda14c59a9eff82fe5adc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_91ad101142ff420539899cbaadbbb34d">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c2d38a65bf3a4106cd17775ea1a6a2e4" level="file">
+          <did>
+            <unittitle>Caravajal, Jose M. J. To Chatham Roberdeau Wheat. Expects a visit from
+              him.</unittitle>
+            <unitdate datechar="creation" normal="1854-11-15/1854-11-15" type="inclusive">1854,
+              November 15 -</unitdate>
+            <physdesc id="aspace_1a7289b49221f1a996fe7984aad79dae">Autograph letter signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_93c1e04d755ffef75304630b8635645b" label="box" type="box"
+              >5</container>
+          </did>
+          <acqinfo id="aspace_5d61c5143e2fad6c105b6ec92157d96a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Reed Book Shop, New Carlisle, Ohio. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4eb62ee4c55e9f2bf2fd581c36d46ac2" level="file">
+          <did>
+            <unittitle>Lutheran church in Saxony. Einleitung von der Grundlage der Christl. Lehre:
+              Lutheran catechism copied by members of a confirmation class in Saxony.</unittitle>
+            <unitdate datechar="creation" normal="1854/1854" type="inclusive">1854 -</unitdate>
+            <physdesc id="aspace_7cb9263164b4ccbcf4df5a859a0188eb">Autograph document 68 p. 21
+              cm.</physdesc>
+            <container id="aspace_5b1df9a41c45d678ee035e9853b6ecf6" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_346d12d3db2150b2dfd4825f23f6a79f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Initials "G. F." on cover</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e78c42e3653cb78577d1f60195948bfa">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Professor Norbert Fuerst, German department, Indiana University, Bloomington,
+              Indiana. <date normal="1964">1964.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_36080a50cdc17483e84f62876178415a" level="file">
+          <did>
+            <unittitle><persname>Mathews, Anne (Jackson), 1782?-1869, actress.</persname> To Mrs.
+              Thomas Potter Cooke. Relates to personal matters.</unittitle>
+            <unitdate datechar="creation" normal="1855-01-08/1855-01-08" type="inclusive">1855,
+              January 8 -</unitdate>
+            <physdesc id="aspace_7ece34916ca980ddb55da443ba5466ea">Autograph letter signed 8 p. 18
+              cm.</physdesc>
+            <container id="aspace_e36d3d1e8b6120779523cfe2b22b281f" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_53bb0056d7a8b2c592cc79b139bd3606">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Mrs. Mathews, <title render="italic">Tea-table Talk.</title>
+                London, 1857.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_94b445a997ab8cfe84b09b322722ea0f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_35a3ec17d2bf7b61fcfedbced4ed4ecc" level="file">
+          <did>
+            <unittitle>Fabre, Charles. Lettercopy book largely to Admiral Reynaud</unittitle>
+            <unitdate datechar="creation" normal="1855-05-09/1864-05-03" type="inclusive">1855, May
+              9-1864, May 3</unitdate>
+            <physdesc audience="internal" id="aspace_396c8b8436e1d05a10590bfb02907818">Autograph
+              document signed 114 p. 40.1 cm.</physdesc>
+            <container id="aspace_ce7feed769430f87ed84010f158638e9" label="Mixed Materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo audience="internal" id="aspace_63e86327e62a312e4e3f63750dd35d93">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Coulet, Paris. June 16, 1980</p>
+          </acqinfo>
+          <scopecontent audience="internal" id="aspace_8d632ebb3e1078222bf91163dd956889">
+            <head>Scope and Contents</head>
+            <list audience="internal" type="ordered">
+              <item>Bound in marbelized paper over board with linen spine</item>
+              <item>Name of C. Fabre found on p. 21 and 40; personal reference in an invitation on
+                page 17</item>
+              <item>Several missing pages</item>
+              <item>Letters chiefly to Admiral Aime Felix Saint Elme Reynaud, 1808-1876, French
+                naval commander, reporting ship movements from on board the Gregeios while stationed
+                at Bone, Algeria, 1855-1856 (p. 1-20) and on board the steamer Catinat, 1861-1864
+                (p. 20-114) reporting from Brest, Halifax, New York, Hampton Roads, New Orleans,
+                Fort Royal in Martinique, Bermuda, Caracas, and Havana</item>
+              <item>Includes two extracts from the log of the Catinat for 1861, Aug. 23-Sept 1 and
+                Sept. 26-Oct. 8 (p. 40 and 43); letter of 1862, June 8, addressed to American rear
+                admiral, Louis Malesherbes Goldsborough, 1805-1877 (p. 55-56); a letter of 1863,
+                Feb. 27 reporting on a voyage to Caracas, Venezuela (p. 73-74); drawing of
+                half-figure of a naval officer on p. 97; personages and events of the American Civil
+                War, especially Benjamin Franklin Butler, 1818-1893 (passim), and (amont other),
+                Nathan Prentiss Banks, Pierre Gustave Toutant Beauregard, Jerome Napoleon Bonaparte,
+                Jefferson Davis, David Glasgow Farragut, William Henry Seward, the Monitor and the
+                Merrimac Battle at Hampton Roads (p. 59-62), Black troops and slavery (p. 92-95,
+                102-109), the Red River Campaign of 1863 (p. 100-102), and William Tecumseh
+                Sherman</item>
+              <item>See bookseller's description in Vertical File</item>
+              <item>In French</item>
+            </list>
+          </scopecontent>
+        </c02>
+        <c02 id="aspace_8ce41af639b9b5fb019ec60bd0cf06c3" level="file">
+          <did>
+            <unittitle>Torres, Juan de Montagu. Commercial dictionary for trading between Britain
+              and South America.</unittitle>
+            <unitdate datechar="creation" normal="1856-11/1856-11" type="inclusive">1856, November
+              -</unitdate>
+            <container id="aspace_5c090cb9c4e1f89cd1175dc9c19a575d" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_35b40f53fa811ce7d4db6ed853e513df">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Inscribed by John Hodgetts, Birmingham.</item>
+              <item>Clasp on cover</item>
+              <item>Includes manuscript notes and portrait</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_57325db877f11b470467ce4805d547d1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Pickering and Chatto. <date normal="2004">2004.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7aad2ec77513aa5872170ffb0faf6633" level="file">
+          <did>
+            <unittitle>Dickens, Catherine Hogarth, 1816?-1879. Tavistock House, London, England. To
+              "Mr. Webster." Requests a box at the Adelphi for Monday night.</unittitle>
+            <unitdate datechar="creation" normal="1857-12-25/1857-12-25" type="inclusive">1857,
+              December 25 -</unitdate>
+            <physdesc id="aspace_72898a2b0292572d19a94cc0eeb82f23">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_5836342d3993357777792b077cc31e39" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_c6c8107a7c21731d2c39bdc9297caa2b">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_91caf77d8cf8a65e07a129edb075f329" level="file">
+          <did>
+            <unittitle><persname>Faraday, Michael, 1791-1867, chemist.</persname> London, Royal
+              Institution. To Mark Seguin, Aine. "I have a great respect for the mathematicians for
+              what they can do, but I wish they would give us, at the end of their papers, the
+              scientific physical truth in plain language. I mean <emph render="italic">the
+                conclusion</emph> not the logic."</unittitle>
+            <unitdate datechar="creation" normal="1858-02-25/1858-02-25" type="inclusive">1858,
+              February 25 -</unitdate>
+            <physdesc id="aspace_4156e11c696c28b626f81d5bacbb7a8c">Autograph letter signed 4 p. 21
+              cm.</physdesc>
+            <container id="aspace_3dd18bd30bc81990ff922e3ad3c020fc" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_3ec5602a4e8fd9b115e7e68537801433">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Professor Walter John Moore, Department of Chemistry, Indiana University,
+              Bloomington, Indiana, 47401. <date normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0f13230e016c79578bb28c18b28ec0db" level="file">
+          <did>
+            <unittitle><persname>Cotton, Henry, 1789-1879, bibliographer.</persname> To John Ribton
+              Garstin. Deals with the index, corrections, and proofs for volume 5 of Cotton's <title
+                render="italic">Fasti Ecclesiae Hibernicae...</title> Dublin, Hodges and Smith,
+              1860.</unittitle>
+            <unitdate datechar="creation" normal="1860-02-04/1860-07-21" type="inclusive">1860,
+              February 4-July 21 -</unitdate>
+            <physdesc id="aspace_52747ef6025925ffc55c991423d59d67">Autograph letter signed 40 p. 18
+              cm.</physdesc>
+            <container id="aspace_1b340a960fcc9f1921416ed813dd7d99" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_ed3e7a93fac8c4daa7855c5925c9d0ef">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by 1) a letter from James Henthorn Todd to John Ribton Garstin, Jan.
+                11, 1864, autograph letter signed 3 p. 13 cm.; 2) a letter from Charles Philip
+                Cotton to John Ribton Garstin, Feb. 11, 1877, autograph letter signed 1 p. 16 cm;
+                and 3) miscellaneous notes, autograph note signed 3 p. 20-26 cm.</item>
+              <item>Removed from Cotton's <title render="italic">Fasti Ecclesiae
+                  Hibernicae...</title> Vol. 6, Supplement. Dublin, James Charles, 1878 (BX5590
+                .C85).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b7b58132534e343974e13438f0f5ec88">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1954">1954.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_632333fab0daa22b96745e766293b508" level="file">
+          <did>
+            <unittitle>Gillette, W. H., fl. 1863. Autograph book.</unittitle>
+            <unitdate datechar="creation" normal="1861-01-09/1863-08-16" type="inclusive">1861,
+              January 9-1863, August 16 -</unitdate>
+            <physdesc id="aspace_62dbde505582f35de635f971c3ca77f2">Autograph document 55 p. 20
+              cm.</physdesc>
+            <container id="aspace_356bedb62e4207cd172a913ecdfa33da" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_2263a29508e392b410758dedc2d952c6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Frank Wilson, dealer, Boston, Massachusetts. <date normal="1961"
+                >1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7f37115ecd61724aff19b8aeb906eec3" level="file">
+          <did>
+            <unittitle><persname>Radcliffe, Thomas Bilton, 1812-1866, actor, stage
+                manager.</persname> 195 Broadway, Cincinnati, Ohio. To Samuel Francis Bilton, Esq.,
+              Barrister, Chancery Chambers, Quality Court, London, England. "I am now engaged in my
+              profession here in this City and am in receipt of a Salary amounting to over eight
+              pounds sterling ($45.00) per week. But I suffered many reverses during the stagnation
+              of business and the thrilling excitement of this Civil War."</unittitle>
+            <unitdate datechar="creation" normal="1861-12-12/1861-12-12" type="inclusive">1861,
+              December 12 -</unitdate>
+            <physdesc id="aspace_8a13897964590b29d28cda34bf645896">Autograph letter signed 3 p. 32
+              cm.</physdesc>
+            <container id="aspace_c9b6457552c73a78322f1dc510e7e539" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_62392a5f54e1800c4d1b258723bee12b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Blue stationary</item>
+              <item>Letter has been silked</item>
+              <item>Accompanied by typescript of letter</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d1e3f33b3877675d0d03d8a5ef9346fd">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ringwood, Hants, England. <date normal="1975"
+              >1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2e75438f401e65f6e060b814120d884c" level="file">
+          <did>
+            <unittitle>Collection of Icelandic letters written in verse, 1862-1897.</unittitle>
+            <unitdate datechar="creation" normal="1862/1897" type="inclusive">1862-1897 -</unitdate>
+            <physdesc id="aspace_744c2a7bc8ff18e5a185576cde746266">Autograph letter signed 203 p. 18
+              cm.</physdesc>
+            <container id="aspace_7dc3d4176199dc549577805ab9233958" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_dd38a6a230e611ebc45c12c2f5508e8c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On verso of front flyleaf is a note by E. M. Thorsteinson dated April
+                1953.</item>
+              <item>Immediately preceding page 180 there are twenty-two pages of blue paper.</item>
+              <item>Bound in paper boards.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_80b63b2e79b903b36f8816e815c8f304">
+            <head>Immediate Source of Acquisition</head>
+            <p>Found among Icelandic literature in the Main Library, Indiana University,
+              Bloomington, Indiana. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b95de6cf106eddf01eab8457761d7553" level="file">
+          <did>
+            <unittitle><persname>Peabody, Nathaniel, fl. 1865, pharmacist.</persname> Dorchester,
+              MAssachusetts. To Mary Tyler (Peabody) Mann. "Please send all the things you
+              mention."</unittitle>
+            <unitdate datechar="creation" normal="1863-06-30/1863-06-30" type="inclusive">1863, June
+              30 -</unitdate>
+            <physdesc id="aspace_fb61df095a3add600283028c6af44278">Autograph letter signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_1e2f2fa67649e58ed9cb3aa5be82007c" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_34e077e2bb2bf9b85674f7ddeb9f3e76">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Peabody was a homeopathic pharmacist doing business in Boston. He was Nathaniel
+                Hawthorne's brother-in-law, Hawthorne having married Sophia Peabody.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8899172b783bd28e58398302e1d91e6e">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d897980252b049f9f8c741e552617630" level="file">
+          <did>
+            <unittitle><persname>Peabody, Nathaniel, fl. 1865, pharmacist.</persname> To Mary Tyler
+              (Peabody) Mann. Requests a loan of $24.</unittitle>
+            <unitdate datechar="creation" normal="1865-02-27/1865-02-27" type="inclusive">1865,
+              February 27 -</unitdate>
+            <physdesc id="aspace_761dd0ca9ff50e8aa8d05477036d3885">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_d206db66275ad63cd42a5a748834e3a6" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_fb638f387bc8d4413c359f07d1a3dbc9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Peabody was a homeopathic pharmacist doing business in Boston. He was Nathaniel
+                Hawthorne's brother-in-law, Hawthorne having married Sophia Peabody.</item>
+              <item>The Clapp referred to in the letter was Otis Clapp, of the Boston pharmacy Otis
+                Clapp which continued to operate until the 1950s, "and without benefit of a soda
+                fountain and such-like."</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ba282c954ffd865d5cff9cd9c890e043">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ead2499569ec1d18fa684ea0ad0102ec" level="file">
+          <did>
+            <unittitle><persname>Peabody, Nathaniel, fl. 1865, pharmacist.</persname> Dorchester,
+              Massachusetts. To Mary Tyler (Peabody) Mann. Deals with finances.</unittitle>
+            <unitdate datechar="creation" normal="1865-03-19/1865-03-19" type="inclusive">1865,
+              March 19 -</unitdate>
+            <physdesc id="aspace_5249b7c52950828ab2c02f09ee4bcb96">Autograph letter signed 5 p. 25
+              cm.</physdesc>
+            <container id="aspace_c52b5f607e1ed36afbf6d9117fe26115" label="box" type="box"
+              >5</container>
+          </did>
+          <scopecontent id="aspace_d26abc3d67ea50b9e8ff95203bef8170">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Peabody was a homeopathic pharmacist doing business in Boston. He was Nathaniel
+                Hawthorne's brother-in-law, Hawthorne having married Sophia Peabody.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_97685647cd7744208a4d3480da1796c8">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a2f54a37fe1a390c80672877b88ba054" level="file">
+          <did>
+            <unittitle><persname>McKiernan, George S., fl. 1865, businessman.</persname> Chicago,
+              Illinois. Letter copybook.</unittitle>
+            <unitdate datechar="creation" normal="1863-04-23/1865-04-29" type="inclusive">1863,
+              April 23-1865, April 29 -</unitdate>
+            <physdesc id="aspace_a90e4618195869483b3a76cff2e922a0">Autograph document signed 134 p.
+              29 cm.</physdesc>
+            <container id="aspace_03f465c86ba5b9f75faabcf06c2dabd2" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_f5111485b0c107a90cb47fd5674090d0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Found in the Indiana University Library. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ae69a79d856fc2e2d98dee5dd00f1c70" level="file">
+          <did>
+            <unittitle><persname>Waring, George, 1806-1878, editor.</persname> To William Fison.
+              Letter presenting a volume to him (Fison) in recognition of his cooperation towards
+              its publication and in the settlement of family affairs "in reference to the residuary
+              legatees."</unittitle>
+            <unitdate datechar="creation" normal="1865-11-06/1865-11-06" type="inclusive">1865,
+              November 6 -</unitdate>
+            <physdesc id="aspace_f561e0f85338f6cbfeda9c027cdf26cd">Autograph letter signed 2 p. 15
+              cm.</physdesc>
+            <container id="aspace_7c6ac602f85fc0e32fb408df7c972ad8" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_22a55255b81acc12b4504befe87ea072">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on the second blank leaf of Bosworth, ed., <title render="italic">The
+                  Gothic and Anglo-Saxon Gospels with the versions of Wycliffe and Tyndale.</title>
+                London, John Russell Smith, 1865 (Lilly BS2549 .A4 1865).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_354205a8bc9b959c6b2dada0e6be4213">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_baeee209718c38f4227a743d66a56a19" level="file">
+          <did>
+            <unittitle>Wylie, W. T., Bellefonte, Pennsylvania. Seventy-three letters and cards to W.
+              T. Wylie in answer to his request for prayers to include in a volume of devotions for
+              schools.</unittitle>
+            <unitdate datechar="creation" normal="1865-10-23/1866-03-12" type="inclusive">1865,
+              October 23-1866 March 12 -</unitdate>
+            <physdesc id="aspace_c071e641d38c802b7a8ef166dda80082">Autograph letter signed 87 p.
+              7-26 cm.</physdesc>
+            <container id="aspace_2f96ff6edb5898444f1411255b457f11" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_9c6bae07e488aa5b1bd6fed0faee6e3d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_32d21364f0e38b80108b42f2de3c7da0" level="file">
+          <did>
+            <unittitle>Radcliffe, Thomas Bilton. To Rawle, George</unittitle>
+            <unitdate datechar="creation" normal="1865-12-09/1865-12-09">1865, December 9</unitdate>
+            <container id="aspace_9a8fb86211300afc7d2f0742ba041a36" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_c75a88d91ab129a8ae8d5fa98ee50056" level="file">
+          <did>
+            <unittitle><persname>Radcliffe, Thomas Bilton, 1812-1866, actor, stage
+                manager.</persname> 67 Laurel Street, Cincinnati, Ohio. To Jane (Bilton) Rawle (Mrs.
+              George Rawle). "...I have received no answer, either from you or my brother
+              Samuel...Pike's Opera House is in ashes--my loses are a considerable part of my
+              wardrobe &amp; properities valuable manuscript Books..." He says Pike plans to build a
+              new theatre in New York "the most splendid...on this Continent."</unittitle>
+            <unitdate datechar="creation" normal="1866-04-08/1866-04-08" type="inclusive">1866,
+              April 8 -</unitdate>
+            <physdesc id="aspace_f55b0d4218384aba446053a1b4ed8424">Autograph letter signed 2 p. 25
+              cm.</physdesc>
+            <container id="aspace_b32d0ff4b1ae39c77bce816acec51235" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_04dc5fd52bc4be7e296304d0eeeb1f89">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ringwood, Hants, England. <date normal="1975"
+              >1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9fff746ba5b2e4e593a7e0df75d5aa43" level="file">
+          <did>
+            <unittitle>Alesson y Millan, Diego, captain of the port of Ponce. Certificate of the
+              arrival and departure of the "Barca" Louisa Cook.</unittitle>
+            <unitdate datechar="creation" normal="1866-04-21/1866-04-21" type="inclusive">1866,
+              April 21 -</unitdate>
+            <physdesc id="aspace_eb038fd18812d56e8d0af16f4638ffd2">Document signed 1 p. 30
+              cm.</physdesc>
+            <container id="aspace_06cffb557023f8f084bad583cb339a2c" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_ebf41b3081a2282ede9ee5403bb8d062">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Old Authors Farm, Morrisburg, Ontario. <date normal="1963"
+              >1963.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5fa5324bd41eac802c9260a11fa9f08d" level="file">
+          <did>
+            <unittitle><persname>Pitman, Sir Isaac, 1813-1897, inventor of phonography.</persname>
+              To Mr. Rumball. Urges Rumball to advocate phonography in his lectures on phrenology
+              and comments on success of the system.</unittitle>
+            <unitdate datechar="creation" normal="1866-11-11/1866-11-11" type="inclusive">1866,
+              November 11 -</unitdate>
+            <physdesc id="aspace_467314616c9db439328a50a48fef4b9e">Autograph letter signed 4 p. 18
+              cm.</physdesc>
+            <container id="aspace_70c5749f29ebf29ee4b3a6282468d39d" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_f1d09c42d3e64f5fcfa326dc1c7d32ca">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Carnegie Book Shop, 140 East 59th Street, New York, New York. <date
+                normal="1960">1960.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a3eb83511564c8c2c1390f88bd46115d" level="file">
+          <did>
+            <unittitle><persname>Gale, George, 1816-1868, lawyer.</persname> Galesville, Wisconsin.
+              To Increase Allen Lapham. Requests Lapham to examine his recent book "and write me
+              your opinion as to its general accuracy in statement of facts."</unittitle>
+            <unitdate datechar="creation" normal="1867-12-23/1867-12-23" type="inclusive">1867,
+              December 23 -</unitdate>
+            <physdesc id="aspace_961d56bf9f6f581571a78b2fc59b5a29">Autograph letter signed 2 p. 19
+              cm.</physdesc>
+            <container id="aspace_5c3e0e696e10e24fff2bb3e19f74a46e" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_802c478579fcbb5323800a532be3e909">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from George Gale's <title render="italic">Upper Mississippi...</title>
+                Chicago, Clarke and Co. New York, Oakley and Mason, 1867 (Lilly F597 .G15
+                1867).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_5aa2a72d4409cfd7af2580c0f0a6b7fa">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7bd36291aebeb478f96bb05c376cc7b6" level="file">
+          <did>
+            <unittitle><persname>Walsh, Robert G. H., naval officer.</persname> Bath. "Signal
+              book...carried...night and day, during the blockade of Alexandria by the Squad of Line
+              of battleships...1840..."</unittitle>
+            <unitdate datechar="creation" normal="1868-06/1868-06" type="inclusive">1868, June
+              -</unitdate>
+            <physdesc id="aspace_f5cb96d67f79e7111e044c8d149996b3">Autograph document signed 28 p. 8
+              x 12 cm.</physdesc>
+            <container id="aspace_5d18f109724e9f1048d6b3327c9d54dc" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_692900ab3e7362a6e3975baa71c6f405">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Neatly drawn colored illustrations of lights and flags including the flags of
+                the fleet at Alexandria</item>
+              <item>Accompanied by a photograph of Walsh</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_31d7d356a422490890b60c0ad9b3fa93">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hants, England. <date
+                normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_74412cf0482bdd324e1095f2f906d03f" level="file">
+          <did>
+            <unittitle><persname>Favre, Gabriel Claude Jules, 1809-1880, statesman.</persname> Note
+              on the Franco-German conflict.</unittitle>
+            <unitdate datechar="creation" normal="1871-01-23/1871-01-23" type="inclusive">1871,
+              January 23 -</unitdate>
+            <physdesc id="aspace_04da2cafc1a4760c95ee26b6e03254bb">Autograph document signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_07b3f7ca773dc5aaa1ff38ddfeaa9d62" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_99e9807b37ea2003ad5e454d21581eeb">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+              <item>Penciled note in blue refers to Bismarck</item>
+              <item>Further blue penciled notes may be found in the following volume</item>
+              <item>Removed from Jules Favre, <title render="italic">Gouvernement de la Defense
+                  Nationale...</title> Paris, Henri Plon, 1872 (DC310 .F27 Vol. 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_77dc8fd5e443e519763c30719a0e6c6c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5f3dd094a8fa8fb1c6c3e806669c15ce" level="file">
+          <did>
+            <unittitle><persname>Forster, John, 1812-1876, biographer, dramatic critic.</persname>
+              Palace-Gate House, Kensington, W. London, England. To "My Dear Sir." Deals with
+              corrections in book.</unittitle>
+            <unitdate datechar="creation" normal="1871-11-10/1871-11-10" type="inclusive">1871,
+              November 10 -</unitdate>
+            <physdesc id="aspace_fb088284f85565cfb15a7829c054e856">Autograph letter signed 3 p. 15
+              cm.</physdesc>
+            <container id="aspace_e8a921cae36711e8e9c31eac00cf40c6" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0856bfaf352e70c38ef46da810bba422">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7ba0cb4575f555ada03235dd07b9d93d">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b7ff0a485db88e3d8110bbbad8b62e9e" level="file">
+          <did>
+            <unittitle><persname>Blanc, Louis, 1811-1882, socialist leader.</persname> Paris, 96 Rue
+              de Rivoli. To "Chere Miss Davies." An appeal for funds for those in
+              prison.</unittitle>
+            <unitdate datechar="creation" normal="1871-11-27/1871-11-27" type="inclusive">1871,
+              November 27 -</unitdate>
+            <physdesc id="aspace_8ac979d174142732ae5facf3efda9826">Autograph letter signed 1 leaf 21
+              cm.</physdesc>
+            <container id="aspace_19b4a4cb860027f813e83a791df31a9f" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_8bed47ec3266f900b4f14cfd408ebc41">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_805cd76a73ca3d2ff64adaa1e8cb180b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_da79b509d23c64058706dfadc7de3376" level="file">
+          <did>
+            <unittitle>Cahier de Composition.</unittitle>
+            <unitdate datechar="creation" normal="1871/1871" type="inclusive">1871? -</unitdate>
+            <physdesc id="aspace_ef7cb42d6394a1e7b3ef66b9ad2b7681">Autograph document 4 p. 22
+              cm.</physdesc>
+            <container id="aspace_3b5816f912262b5ad3a8d03be2134dad" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0456aa378543a39e56538c7fcea50ef3">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Title from blue and gold cover</item>
+              <item>Pages have embossed floral borders from Auray</item>
+              <item>Contents: Complements Directs (e.g., Le Soldat defend sa patrie); Complements
+                Indirects (e.g., Le jour succede a la nuit); Memoire, Rennes France le 1er Juin 1871
+                (e.g., 3 douz de crayons a 0 fr 10 c 1e crayon equals 3 f 60 c); Arithmetical
+                calculations for Memoire on previous page</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1381761d004f21428f62f570278e974b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_817be0854ff92be92715d2300f2fd27a" level="file">
+          <did>
+            <unittitle><persname>Barnum, Phineas Taylor, 1810-1891, showman.</persname>
+              Autograph.</unittitle>
+            <unitdate datechar="creation" normal="1872-11-02/1872-11-02" type="inclusive">1872,
+              November 2 -</unitdate>
+            <physdesc id="aspace_acb1fb774e5c0e1176aa68457482fe0b">Autograph document signed 1 p. 5
+              cm.</physdesc>
+            <container id="aspace_1d8eabf64124611e3442be26d1e76ad2" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_3015bb61f23899c8ca2188c619d3153c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Lilly Library copy of Barnum's <title render="italic">Struggles and
+                  triumphs: or, forty years' recollections...</title> Buffalo, New York, Warren,
+                Johnson &amp; Co., 1873 (Lilly GV1811 .B26 1873a).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e4bffe0a67333737502636690dd61f5d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1964">1964.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2daaf86257c9779cd56827e53b96c628" level="file">
+          <did>
+            <unittitle><persname>Weber, Max Maria, freiherr von, 1822-1881, railway
+                official.</persname> To Minnie Hauk. Only the most pressing business could prevent
+              him from placing the three volumes at the pretty feet of Fatimas.</unittitle>
+            <unitdate datechar="creation" normal="1872-12-08/1872-12-08" type="inclusive">1872,
+              December 8 -</unitdate>
+            <physdesc id="aspace_4a4b94b3e13c0baf3bd4b02ef061e5b9">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_01a28b5c565c65f553bd1f91111cf6ad" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_930bf2bc11c077c57b937e931b815dd5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In German</item>
+              <item>Accompanied by an autographed photograph of Weber</item>
+              <item>Includes translation. Letter was translated by Frieda Schneider Andressohn (Mrs.
+                John C. Andressohn)</item>
+              <item>Removed from Weber's <title render="italic">Carl Maria von Weber. Ein
+                  Lebensbild.</title> Leipzig, Ernst Keil, 1864 (Lilly ML410 .W3 W3, vol. 1).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_83a2b2392fbcae9247b48381a8e744ed">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a5df2762b78f0b0cb7a552c96db528a4" level="file">
+          <did>
+            <unittitle>Belfast. District Model National School. Certificate of merit and award of
+              premium to Martha Irvine for superior proficiency in the prescribed course of the 2nd
+              class.</unittitle>
+            <unitdate datechar="creation" normal="1872-12-19/1872-12-19" type="inclusive">1872,
+              December 19 -</unitdate>
+            <physdesc id="aspace_3fc50cf6d4a73f5646cdcb9f0eeb4527">Autograph document signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_8dcaa6dccd1089584131eda4f88085a1" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_051c557c67fc4063c465371380452b08">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Arthur F. Bentley, R. R. 2, Paoli, Indiana. <date normal="1954"
+                >1954.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2d7ce88e421d448726a742f395d48566" level="file">
+          <did>
+            <unittitle><persname>Plimsoll, Samuel, 1824-1898, politician, social
+                reformer.</persname> 111 Victoria Street, London S.W., England. To Nottage, Esq. "If
+              you feel any hestitation about accepting a present from a stranger you may send me an
+              equivalent in the photographs that you are taking."</unittitle>
+            <unitdate datechar="creation" normal="1873-03-18/1873-03-18" type="inclusive">1873,
+              March 18 -</unitdate>
+            <physdesc id="aspace_1fed7b7287db029963bcc21e45e41685">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_e9ce0ada0a5e61ee84954e9850e7cab9" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_6d27c3251a866eb721c7ffe7a749a119">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Crest and street embossed on stationary</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d3b6ce79ee70e04f3895234310bc52b7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. B. Harding-Edgar, Benisa (Alicante), Spain. <date normal="1972"
+                >1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5d08e06d5bf78f096254f8f6c6348b87" level="file">
+          <did>
+            <unittitle>Journal of a tour in Austria and northern Italy. There are comments on the
+              stay in Vienna, Graz, Trieste, Venice, Florence, and Rome. Comments on features of
+              historical and archaeological interest as well as interesting descriptions of
+              accommodations and travelling arrangements are made.</unittitle>
+            <unitdate datechar="creation" normal="1874-09-18/1874-12-31" type="inclusive">1874,
+              September 18-December 31 -</unitdate>
+            <physdesc id="aspace_6e1a56acf8a9f62e143826f3fd17238d">Autograph letter 138 p. 24
+              cm.</physdesc>
+            <container id="aspace_a82c33e766bfd3872395af07e4196ade" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_69c38854f142c96f7d527059d3a88dbf">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Included are also ten photos of places, 19 engravings, two small water colors
+                and a sketch map.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8ccdb9781e026a2399c4920ed6e03fa2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ltd., Ringwood, Hants, England. <date normal="1974"
+                >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a81eef38c7ed6ec887fa7884a53d1292" level="file">
+          <did>
+            <unittitle><persname>Derby, Edward Henry Stanley, 15th earl of, 1826-1893,
+                statesman.</persname> Passport issued to Breadalbane, Gavin Campbell, 7th earl of,
+              in the name of her majesty, Queen Victoria.</unittitle>
+            <unitdate datechar="creation" normal="1877-11-28/1877-11-28" type="inclusive">1877,
+              November 28 -</unitdate>
+            <physdesc id="aspace_dc7f9f905d7fa26f4dc5bfe6a97455fc">Document signed 1 p. 28 x 38
+              cm.</physdesc>
+            <container id="aspace_10b8a6ae4977f0d3a7ffaac84b7d108c" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_1fc454e5355b7e9d93a70f205a7d4e99">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Partly printed</item>
+              <item>Also signed by the earl of Breadalbane</item>
+              <item>Coat of arms of United Kingdom at top of passport</item>
+              <item>Coat of arms of earl of Derby at bottom of passport</item>
+              <item>Embossed government seal in lower left-hand corner</item>
+              <item>Spanish stamp and signatures on verso, March 1, 1880</item>
+              <item>Folded into brown morocco carrying case</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0b9530fc2a618cbcb059f4260318f6ab">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3ba5e3a335f281f2e94ef910f1a72b7c" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname> 4 Orme
+              Square, Bayswater, W. To Frederick William Hawkins. "I am in receipt of yours and
+              eclose cheque for Four Guineas..."</unittitle>
+            <unitdate datechar="creation" normal="1877-12-21/1877-12-21" type="inclusive">1877,
+              December 21 -</unitdate>
+            <physdesc id="aspace_09245afa61cbfab7658a179b797a9a19">Autograph letter signed 1 p. 13
+              cm.</physdesc>
+            <container id="aspace_7e98a33ed3f397cf469a488ad57aa0de" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_96f5dd7954781bd03a78ea12ceab830a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W. 1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5b7f473ce3bacfb1b467ad5c9e133e18" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname>
+              Southport. To Frederick William Hawkins. "Business splendid everywhere with me - next
+              week I'm at Princes Theatre Manchester - don't forget to speak to your
+              friend."</unittitle>
+            <unitdate datechar="creation" normal="1878-10-19/1878-10-19" type="inclusive">1878,
+              October 19 -</unitdate>
+            <physdesc id="aspace_3625fef7429e03ce9a96313d0348c62d">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_7e7c5eefdbf1f3ae9d41ac8a44ff1e47" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_e6ab680eba94e1bb033f59e4398789d8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W. 1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f04e45d7895cc28f0dcb39a7a416fb18" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname> Garrick
+              Club. To Frederick William Hawkins. "I went to Lock &amp; Whitfield had sitting...may
+              be up one day next week...what a pity you can't use any photos except Lock &amp;
+              W's."</unittitle>
+            <unitdate datechar="creation" normal="1879-04-09/1879-04-09" type="inclusive">1879,
+              April 9 -</unitdate>
+            <physdesc id="aspace_9f9c99041f315cedadf316a4649bf5b2">Autograph letter signed 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_49dc5cc7fcbe3f6816803e36bd8fabd2" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_677708a2cf4e54e6b3f8d2a864803d9d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W. 1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a4ea9e005d39569b14649d2d025e917d" level="file">
+          <did>
+            <unittitle><persname>Darwin, Charles Robert, 1809-1882, naturalist.</persname> Down,
+              Beckenham, Kent. To Mr. Paget. Expresses thanks for the assistance given him in
+              connection with a life of Dr. Erasmus Darwin which he was writing.</unittitle>
+            <unitdate datechar="creation" normal="1879-07-14/1879-07-14" type="inclusive">1879, July
+              14 -</unitdate>
+            <physdesc id="aspace_35bb1ccdc2bcbc20936a89058c61828a">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_5207d424ee079a5f1824415f17153479" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_e44cde84866d4d54b9b8d3e42bfd199f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ba164f361bb0d8a3ea8517b00ef3a079">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_65bd9c8cd88c435af3191785fc327744" level="file">
+          <did>
+            <unittitle>Rand, Rev. S. T. "Brief Catechism in Micmac Hieroglyphics. With the Micmac
+              words added in Roman characters."</unittitle>
+            <unitdate datechar="creation" normal="1870/1879" type="inclusive">Ca. 1870s -</unitdate>
+            <container id="aspace_7aa489e69140c6dba2fe8264a2ea10ec" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0c9111c31453e566d6902e88ff7665aa">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Note on first page reads "Described in Pilling's Algonquian Bibliography, p.
+                426." Photocopy of citation included</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_73ffa8c72349296899208f42b5956798">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Philadelphia Rare Books &amp; Manuscripts Company. P.O. Box 9536.
+              Philadelphia, PA. 19124. <date normal="1998">1998.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4bc3c8f88bcf0031ad3f76d860cb2165" level="file">
+          <did>
+            <unittitle><persname>Rylands, John Paul, 1846-?, author.</persname> Highfields,
+              Thelwall, Warrington. To "Dear Sir." Concerns bookplates of his family.</unittitle>
+            <unitdate datechar="creation" normal="1880-11-26/1880-11-26" type="inclusive">1880,
+              November 26 -</unitdate>
+            <physdesc id="aspace_d27371a964b1daa46ab85a2db5dcafd6">Autograph letter signed 4 p. 18
+              cm.</physdesc>
+            <container id="aspace_2c179c8536038fb3b233d8cb1b0b2f45" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0073eb29b0dbc11726fd069055e02247">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Collection of Bookplates (Lilly Z688 .B7 W58).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_fc9ac569be20f9abe00713df24a20570">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_13f3b9577cb4c654ee98008ec4203159" level="file">
+          <did>
+            <unittitle><persname>Symington, Andrew James, 1825-?, author.</persname> 10
+              Battlefield...Langside, Glasgow Scotland. To Thomas Gibbons, Esq. Mentions the "A
+              &amp; S Herald" and the "Fireside Herald" and concludes "...the red sun looking in at
+              my window through a windy mist over the busts of Homer Dante &amp; Lord Bacon says
+              'haste'!"</unittitle>
+            <unitdate datechar="creation" normal="1883-11-12/1883-11-12" type="inclusive">1883,
+              November 12 -</unitdate>
+            <physdesc id="aspace_3dd0c9cda976451ec3fc4843206590c1">Autograph letter signed 3 p. 17
+              cm.</physdesc>
+            <container id="aspace_58c5f12128098d21a5a6b887d712129e" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_a9de270d060b166bf172e8cf85aa8343">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_73b1aa85cd4c3665a6c4ce42866453e8" level="file">
+          <did>
+            <unittitle><persname>Bowring, Sir John, 1792-1872, linguist.</persname> To "My dear
+              Fritz." Lucy's health.</unittitle>
+            <unitdate datechar="creation" normal="1883-12-08/1883-12-08" type="inclusive">1883,
+              December 8 -</unitdate>
+            <physdesc id="aspace_b620aeeeb433f3d9598cdee90900d76a">Autograph letter signed 4 p. 18
+              cm.</physdesc>
+            <container id="aspace_429258b1f81c538bf575e0c77b84ecf4" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_fcae216b54440da35d45d5eaedef4528">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from John Bowring's <title render="italic">Translations from Alexander
+                  Petofi, the Magyar poet...</title> London, Trubner &amp; Co., 1866 (Lilly PH3305
+                .B6).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_96ab66dea40fa79542454d8e1218627d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_dd36c7c7561d21676d4a87904e5d4a36" level="file">
+          <did>
+            <unittitle>Chatto, Andrew, publisher. 214 Piccadilly, London, W. England. To H. N. Pyns,
+              100 Harley Street. Regrets that he does not have a portrait of Baron Tauchnitz, but is
+              sending an engraving of Charles Reade.</unittitle>
+            <unitdate datechar="creation" normal="1884-04-23/1884-04-23" type="inclusive">1884,
+              April 23 -</unitdate>
+            <physdesc id="aspace_d9bf81b3bfc4c8c22dbf4b60baf24674">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_b61bbfc86a41f3d13ba2ca6aa6695679" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_8e4088e2569e8075578f2ee632e296c5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Edward Morrill &amp; Sons, Inc., 25 Kingston Street, Boston,
+              Massachusetts, 02111. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3c8ff24af4437fdd23fdb17f6c8189ef" level="file">
+          <did>
+            <unittitle><persname>Wiley, Harvey Washington, 1844-1930, pure food reformer.</persname>
+              New Orleans. To ?. Dislikes New Orleans. On way to Washington. Expects to spend
+              Christmas day with parents in Kent, Indiana and to be back in Washington about January
+              1.</unittitle>
+            <unitdate datechar="creation" normal="1884-12-14/1884-12-14" type="inclusive">1884,
+              December 14 -</unitdate>
+            <physdesc id="aspace_5a932b64d69edd1e942f8b76b7c515d5">Autograph letter signed 4 p. 21
+              cm.</physdesc>
+            <container id="aspace_771ea10e60bdd54591396e76b8d38368" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_ca9e836fb6939e7f16896280545e2def">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a36550008e05da83236b9447dbf50447" level="file">
+          <did>
+            <unittitle><persname>Loving, James Carroll, 1836-1902, cattleman.</persname> One leaf
+              from the original manuscript on cattle brands.</unittitle>
+            <unitdate datechar="creation" normal="1884/1884" type="inclusive">1884 -</unitdate>
+            <physdesc id="aspace_bafdb344d553b8864b5a73ea485c25fe">Autograph document 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_f2d0d16ebe713657d11bdc158900e9f6" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_7a1f061a1f907da2c5e604f5a45640c5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from and reproduced in <title render="italic">The Loving brands
+                  book,</title> manuscript edition. Austin, Texas, Pemberton Press, 1965, p. 16-17
+                (Lilly F596 .L91).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_22235780faf5724b07ec0e013579b986">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_9c778cbe436ed65181adc7eb506e4aa1" level="file">
+          <did>
+            <unittitle>Announcement of the appointment of Chang Yam Hung</unittitle>
+            <unitdate datechar="creation" normal="1884-06-16/1884-06-16">1884, June 16</unitdate>
+            <container id="aspace_62506a281ec1b9f255b910719dc68193" label="Mixed Materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 audience="internal" id="aspace_278e822ce7ad7d1cd7f69c2b3a31fcfc" level="file">
+          <did>
+            <unittitle>Grenville, George. Cover only for letter to Frederick Henry Maitland, 13th
+              Earl of Lauderdale at Hatton Scotland</unittitle>
+            <physdesc audience="internal" id="aspace_f41e5cc0bb0d79b7b91aab5baef0948f">ADS 1 p. 19
+              cm.</physdesc>
+          </did>
+          <acqinfo audience="internal" id="aspace_dfff53e40969fa4cdaaf6d45530819cf">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Charles Apfelbaum, Valley Stream, New York. 1991</p>
+          </acqinfo>
+          <scopecontent audience="internal" id="aspace_9daabf079a59db1ade633b672e9e3919">
+            <head>Scope and Contents</head>
+            <list audience="internal" type="ordered">
+              <item>Bears red wax seal</item>
+              <item>Stamped date: GAJ Sept 1884</item>
+              <item>"Mr. Grenville" in upper left hand corner</item>
+              <item>Stamped circle enclosure of 17/De near the red wax seal</item>
+            </list>
+          </scopecontent>
+        </c02>
+        <c02 id="aspace_bb0005f45960c8bcf0329576d4c24d4d" level="file">
+          <did>
+            <unittitle>Album of autographs, signatures, and letters of musicians, actors,
+              dramatists, and artists, including several undated pieces.</unittitle>
+            <unitdate datechar="creation" normal="1884/1909" type="inclusive">1884-1909 -</unitdate>
+            <physdesc id="aspace_a58884183675cc1a267b62fa2ea77905">Autograph documents signed 127 p.
+              20 cm.</physdesc>
+            <container id="aspace_91cc49deb0afa1fb39c1ee9b47355775" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_3619aaf165a72d3cb306d5df5a872845">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in black with the word Album stamped in gold on the cover</item>
+              <item>Sixty-six blank pages</item>
+              <item>Contents: 1) Cummings, William Hayman, 1831-1915, singer, musician antiquarian,
+                Domine...14 bars of music with words, Feb. 17, 1899; 2) Robson, E. M., "When my cue
+                comes...", May 14, 1902; 3) Couldery, Claudius H., Lento...8 bars of music, Dec. 20,
+                1899, prefaced by a drawing of a kitten; 4-5) blank; 6) Berger, Francesco,
+                1834-1933, pianist, composer, Gavotte...3 bars of music, May 3, 1902; 7) Santley,
+                Sir Charles, 1834-1922, opera siner, It is enough...2 bars of music, Mar. 23, 1899;
+                8) blank; 9) Todhunter, John, 1839-1916, playwright, Aghadoe...5 bars of music with
+                words, Apr. 13, 1899; 10) blank; 11) Moir, Frank Lewis, 1852-1904, song writer, And
+                up and out...3 bars of music with words, Mar. 30, 1899; 12) blank; 13a) Ryland,
+                Henry, 1856-1924, artist, Autograph, Apr. 13, 1904; 13b) Smith, Carlton Alfred,
+                1853-1946, artist, Autograph, Apr. 19, 1904; 13c) Linton, Sir James Dromgole,
+                1840-1916, artist, Autograph, July 27, 1904; 14) Kinsley, Albert, 1853-1946, artist,
+                Autograph, July 22, 1904; 15) Reeves, Herbert Sims, Adelaide di L. V. Beethoven...3
+                bars of music for voice and piano accompaniment, Mar. 27, 1899; 16-18) blank; 19)
+                Silas, Edouard, 1827-1909, organist, composer, Kat-denza from a Nocturne...with
+                Minnie and Tom the cats as Clef marks for the cadenza, n.d.; 20) blank; 21) Prout,
+                Ebenezer, 1835-1909, theorist, composer, From 'Suite de Ballet; Op. 28'...5 bars of
+                music, Nov. 14, 1900; 22) Chauglet, Maud M., Autograph, n.d.; 23a) Hudleston,
+                Jessie, "A poor little dummy am I...", May 13, 1900; 23b) Moore, Jessie, ?-1910,
+                actress, Autograph, 1901; 24-26) blank; 27) Booth, Cecil, R. A., "On such a night as
+                this"...5 bars of music with words, Jan. 1900; 28) blank; 29) Munck, Ernest de,
+                1840-1915, violincellist, Allegro...3 bars of music inscribed to Madame Haroldine
+                Lane, Mar. 31, 1900; 30) blank; 31) Bach, Leonhard Emil, 1849-1902, pianist, Musical
+                symbol inscribed to Mrs. Haroldine Lane, Mar. 29, 1899; 32) blank; 33) Liebling,
+                Georg, 1865-1946, pianist, composer, Piano Concerto, Op. 22...2 bars of music, June
+                10, 1902; 34) blank; 35) Raine, A., Pensee fugitive...3 bars of music, July 19,
+                1902; 36-42) blank; 43) Kate Temple, Will A. Pepper, Howard Barnsley, Chas Neary,
+                Chas Conyers, inscribed under "The White Coon's Bray," 1903; 44-65) blank; 66-67)
+                Payne, Arthur W., 1863-?, violinist, conductor, Andante from Mendelssohn...3 bars of
+                music, Aug. 1904, and photograph of Payne as conductor, Jan. 1, 1907; 68-69)
+                Buccini, Edward, "Order was given to swing there..." accompanied by pencil sketch of
+                mermaids with lyre and a Viking ship, Aug. 22, 1903; 70-76) blank; 77) Turnpenny,
+                Henry, Autograph, Aug. 1904; 78-85) blank; 86-87) Warnford-Davis, A., Lines of
+                Prospero from Act V, Scene I of The Tempest, accompanied by colored drawing of
+                figures on the beach, 1909; 88-96) blank; 97a) Brough, Robert, 1872-1905, portrait
+                painter, Signature signed Bobbie, n.d.; 97b) Weldon, Georgina, 1837-1914, soprano,
+                composer, Admission ticket to the Amphitheatre of Royal Albert Hall, June 6, 1884;
+                97c) Paderewsi, Ignace, Jan, 1860-1941, pianist, Signature, n.d.; 98) blank; 99)
+                Sainton, Joseph, 1878-?, pianist, conductor, Autograph, Sept. 7, 1906; 100) blank;
+                101) Dibdin, Charles, 1745-1814, dramatist, Signature and picture, n.d.; 102a) Ganz,
+                Wilhelm, 1833-1914, organist, Signature, n.d.; 102b) Williams, Bransby, 1870-1961,
+                actor, Autograph, n.d.; 102c) Tree, Sir Herbert Beerbohm, 1853-1917, actor, manager,
+                Signature, n.d.; 103a) Roeckel, Joseph Leopold, 1838-1923, teacher, composer,
+                Signature, n.d.; 103b) Sothern, Edward Askew, 1826-1881, actor, Signature, n.d.;
+                103c) Powell, Maud, 1868-1920, violinist, Signature, n.d.; 104a) Ondricek,
+                Frantisek, 1859-1922, violinist, Signature, n.d.; 104b) Sapelnikov, Vassily,
+                1865-1941, pianist, 3 bars of music, Feb. 1, 1902; 105a) Goldschmidt, Otto,
+                1829-1907, pianist, composer, Note to friend Berger, Aug. 23, 1900; 105b)
+                Unidentified signature; 105c) Olitzka, Rosa, 1873-1949, contralto, Signature, n.d.;
+                106) Marchesi, Blanche, 1863-1940, opera singer, Note in German to unidentified
+                person, n.d.; 107) Kubelik, Jan, 1880-1904, violinist, composer, Beethoven, Op.
+                67...4 bars of music, May 18, 1902; 108) Rosenthal, Moritz, 1862-1946, pianist, Note
+                in German to unidentified person, n.d.; 109a) Unidentified signature; 109b)
+                Unidentified signature; 109c) Dollman, John Charles, 1851-1934, painter, Signature,
+                n.d.; 109d) Backhous, Wilhelm, 1884-?, pianist, Signature, n.d.; 110a) Sauer, Emil
+                von, 1862-1942, pianist, composer, card to George Carr, Feb. 6, 1902; 110b) Albani,
+                Dame Emma, 1852-1930, opera singer, Card to Mr. Berger, Mar. 10, 1902; 111)
+                Moszkowski, Moritz, 1854-1925, pianist, composer, Letter in German to Herr Berger,
+                n.d.; 112) German Sir Edward, 1862-1936, violinist, composer, Letter to Mr. Berger,
+                July 16, 1902; 113) Bridge, Sir John Frederick, 1844-1924, conductor, Letter to
+                Berger, n.d.; 114a) Alma-Tadema, Sir Lawrence, 1836-1912, artist, Signature, n.d.;
+                114b) Elgar, Sir Eward William, 1857-1934, composer, Signature, n.d.; 114c) Black,
+                Andrew, 1859-1920, baritone, Signature, n.d.; 115) Stanford, Sir Charles Villiers,
+                1852-1924, composer, Letter to Mr. Berger, Oct. 1, 1895; 116) Becker, Hugo,
+                1863-1941, violinist, Letter in German to unidentified recipient, Mar. 8, 1902;
+                117a) Browne, Paddie, Quotation mentioning A. W. Pinero, n.d.; 117b) Waller, Lewis,
+                1860-1915, actor, Signature, n.d.; 118) Parry, Sir Charles Hubert Hastings,
+                1848-1918, composer, tenor, Signarure, n.d.; 119a) Chandos, Lloyd, fl. 1938, tenor,
+                Signature, n.d.; 199b) Oxenford, Edward, 1837?-1929, playwright, librettist,
+                Signature, n.d.; 119c) Unidentified autograph, June 12, 1899; 120) Marsick, Martin
+                Pierre Joseph, 1848-1924, violinist, Note in French to unidentified person, Dec. 11,
+                1898; 121a) Joachim, Joseph, 1831-1907, violinist, Signature, n.d.; 121b)
+                Unidentified signature; 121c) Needham, Alicia Adelaide, 1875-1945, composer,
+                Signature, n.d.; 122a) Chevalier, Albert, 1861-1923, music hall comedian, Signature,
+                n.d.; 122b) Unidentified signature, n.d.; 122c) Unidentified signature, n.d.; 122d)
+                Unidentified signature, n.d.; 122e) Unidentified signature, n.d.; 123a) Unidentified
+                signature, n.d.; 123b) Unidentified signature, n.d.; 123c) Unidentified signature,
+                n.d.; 123d) Carmichael, Mary Grant, 1851-1955, pianist, violinist, Signature, n.d.;
+                124a) Mackenzie, Sir Alexander Campbell, 1847-1935, composer, violinist, Signature,
+                n.d.; 124b) Bingham, Clifton, Signature n.d.; 124c) Unidentified signature, n.d.;
+                124d) Unidentified signature, n.d.; 124e) Somervell, Sir Arthur, 1863-1937,
+                composer, Signature, n.d.; 124f) Ernest, Gustav, Signature, n.d.; 125) Arbos,
+                Enrique Fernandez, 1863-1938, violinist, composer, Letter in French to unidentified
+                person, Jan. 16, 1900; 126a) Blumenthal, Jacob, 1829-1908, pianist, composer,
+                Signature, n.d.; 126b) Calsi, J. L., professor, Signature, n.d.; 126c) Janotha,
+                Nathalie, 1856-1932, pianist, composer, Letter to unidentified person, June 30,
+                1899; 127) Unidentified writer of letter from Kew, July 20, 1896.</item>
+              <item>Unmounted pieces include 1) Austin, Walter, Note from 122 St. James Court to
+                Mrs. Lane, Feb. 5, n.y.; 2) Lehmann, Liza Elizabeth Nina Mary Frederika, 1862-1918,
+                soprano, composer, Signature, n.d.; 3) Ronald, Sir Landon, 1873-1938, composer,
+                conductor, Letter to Mrs. Lane, Jan. 10, n.y.</item>
+              <item>The letters to Francesco Berger appear to be to him in his capacity as Honorary
+                Secretary of the Royal Philharmonic Society in London</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_74d186bfa35c0a79fafcbf5b338ac141">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ringwood, Hants, England. <date normal="1975"
+              >1975.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cde749a17d83b9e3ded523aeaee40664" level="file">
+          <did>
+            <unittitle><persname>Harrison, Frederic, 1831-1923, author.</persname> 38 Westbourne
+              Terrace, W., London, England. To "My dear Sir." Concerns literary contribution
+              requested.</unittitle>
+            <unitdate datechar="creation" normal="1885-02-21/1885-02-21" type="inclusive">1885,
+              February 21 -</unitdate>
+            <physdesc id="aspace_e35dc42a1883f098fa5e7803ba664463">Autograph letter signed 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_c25e698a3f24de401a672b62631a7173" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_f477e461c7d972452c322749753b3e49">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b912a1339483d121a307990a6a63696d">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1434c66684ff2d0136ed6f8823e28779" level="file">
+          <did>
+            <unittitle>Sturge, Charles Young. Chilliswood, Tyndall's Park, Bristol. To "My dear
+              Ernest." "With regard to the 'revelations' I have only read the first of the four
+              articles...But the first was quite enough to put one <emph render="italic">an
+                courant</emph> with the agitation, &amp; I have rather shrunk from attacking the
+              others, as they leave a distinctly morbid impression on the mind."</unittitle>
+            <unitdate datechar="creation" normal="1885-08-02/1885-08-02" type="inclusive">1885,
+              August 2 -</unitdate>
+            <physdesc id="aspace_cdbda19694c7d6ea537e01ad36273e83">Autograph letter signed 11 p. 18
+              cm.</physdesc>
+            <container id="aspace_d4c7b56049e05f2321d39d4309605227" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_034c8696c2848db2aebd6e3ff352035a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">The Pall Mall Magazine,</title> XXIII, no.
+                93, Jan. 1901 (Lilly AP4 .P17).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_96fd753a079699fa6123f30d0527b65d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1973">1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6aa63b8630623729e85cb28c90752b48" level="file">
+          <did>
+            <unittitle><persname>Bright, John, 1811-1889, statesman.</persname> To Edwin E. Griffin,
+              2 Colville Terrace, Kensington W. Not familiar with German and therefore unable to
+              judge the merit of the translation.</unittitle>
+            <unitdate datechar="creation" normal="1886-02-17/1886-02-17" type="inclusive">1886,
+              February 17 -</unitdate>
+            <physdesc id="aspace_047c441e006344786d49e2f252153d54">Typescript 1 p. 28 cm.</physdesc>
+            <container id="aspace_4368a7f1f92c3124bd5a193ad76707ea" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_c71de3ce1c8674ba319995004e934fc4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes only typescript (not original)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_59e0e971be37286921fa7f9c2946dd40">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_422c7824301855a67351e67a871f5e5e" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname> Toole's
+              Theatre, King William St., Strand. To Frederick William Hawkins. "Can you 'wake up'
+              the Critic or Editor of The Times! I have revived the 'Serious Family' it has been
+              noticed by all the principal papers except The Times."</unittitle>
+            <unitdate datechar="creation" normal="1886-05-13/1886-05-13" type="inclusive">1886, May
+              13 -</unitdate>
+            <physdesc id="aspace_f1aa63cd21008e4f91aaaffb95509208">Autograph letter signed 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_5e07e6c992d89ca1e5bdfb0ca92c0657" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_ffed2ad196da9d0d7eb8e6bac65a7bd4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W.1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_64c4dae70c93c475553918910d665ba5" level="file">
+          <did>
+            <unittitle><persname>Smith, Henry Preserved, 1847-1927, clergyman, Biblical
+                scholar.</persname> Lane Seminary, Cincinnati. To William Wesley Spangler.
+              Subscription to "Dr. Smith's Spinosa."</unittitle>
+            <unitdate datechar="creation" normal="1886-10-07/1886-10-07" type="inclusive">1886,
+              October 7 -</unitdate>
+            <physdesc id="aspace_f64a3a9a21fb4679bb01ee78aa8bf25a">Autograph letter signed 1 p. 23
+              cm.</physdesc>
+            <container id="aspace_683d648390618b66a7e5f45384f31eab" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_c44805dd3cf53fd1d1b8def6689fba7e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Source unknown. <date normal="1939">1939.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6313c710637186312eae367e8d06f7fe" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname> Toole's
+              Theatre, King William St., Strand. To Frederick William Hawkins. "With much pleasure
+              enclosed for Saturday evening. Come round end of 2nd act of <emph render="italic"
+                >Going it</emph> to my room."</unittitle>
+            <unitdate datechar="creation" normal="1886/1886" type="inclusive">1886 -</unitdate>
+            <physdesc id="aspace_529e6e08f0734f82b703fe108922f61a">Autograph letter signed 1 p. 13
+              cm.</physdesc>
+            <container id="aspace_caf91bc01d596bda46acd409152a3221" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_2a9c62a6a9ea029132b57df82f98745d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W.1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5fc922c7eae23d79d93f5b4a2b80ff31" level="file">
+          <did>
+            <unittitle><persname>Wolle, Francis, 1817-1893, Moravian minister, student of
+                algae.</persname> Bethlehem, Pa. To N. N. Mason. Concerning the publication of
+              Wolle's new volume.</unittitle>
+            <unitdate datechar="creation" normal="1887-03-15/1887-03-15" type="inclusive">1887,
+              March 15 -</unitdate>
+            <physdesc id="aspace_e65f33e8c12005a87efa7a1e687a7463">Autograph letter signed 1 p. 26
+              cm.</physdesc>
+            <container id="aspace_a4841838d56ded5c0548c9be43819e96" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_c81e401e9cc6d1fcdbeff198ad9b0617">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e1b48e6845e67b85ee363dd5cf5f62eb" level="file">
+          <did>
+            <unittitle><persname>Gregg, John Robert, 1867-1948, educator, author.</persname>
+              Light-Line Phonography Institute, Imperial Chambers, Dale Street, Liverpool England.
+              To "Dear Sir." "A person of average ability can easily acquire the entire system in a
+              fortnight by practicing two hours daily."</unittitle>
+            <unitdate datechar="creation" normal="1888-07-19/1888-07-19" type="inclusive">1888, July
+              19 -</unitdate>
+            <physdesc id="aspace_8499a2679dd1182ae99d7af28e95430a">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_05304254f40e1c72a4edc64292ab4291" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0ecc8f90204fd054ed62a5dc322a3b03">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Folded octavo sheet has pencilled notes in French and arithmetic figures in ink
+                on the verso</item>
+              <item>Removed from John Robert Gregg, <title render="italic">Light-line phonography;
+                  the phonetic handwriting.</title> Liverpool: Light Line Phonography Institute, 62
+                Dale Street, 1888 (Lilly from the Ian Fleming Collection).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b2cc4a329d715a8d42c6e00dfd0f68c5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3fbeb89f7ac6c5db8253486993091ae5" level="file">
+          <did>
+            <unittitle><persname>Toole, John Lawrence, 1830-1906, actor, manager.</persname> The
+              Grand Hotel, Trafalgar Square, W.C., London. To Frederick William Hawkins. "I suppose
+              you mean The Dinner is Wednesday the 12th...I've not thought yet about a speech. I've
+              been awfully busy. I expect I shall ramble on."</unittitle>
+            <unitdate datechar="creation" normal="1890-02-03/1890-02-03" type="inclusive">1890,
+              February 03 -</unitdate>
+            <physdesc id="aspace_db745ae5cb24a8b83fc994f1a0569fb9">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_fe9ebfe7d79fdb42aa16f9fde8a48278" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_0d3d3959f58454796734409ac235a468">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcer, 22 Buckingham Gate, London, S.W.1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_045b3a56c49aeb06c9299c9a3967a3c4" level="file">
+          <did>
+            <unittitle><persname>Shuckburgh, Evelyn Shirley, 1843-1906, classical
+                scholar.</persname> Cambridge, Eng. To ? Two letters regarding entries in a
+              manuscript. Psalter in Trinity college library.</unittitle>
+            <unitdate datechar="creation" normal="1891-02-20/1891-03-01" type="inclusive">1891,
+              February 20-March 1 -</unitdate>
+            <physdesc id="aspace_211bb8656bd862bfcf79024177705ea3">Autograph letter signed 7 p. 17
+              cm.</physdesc>
+            <container id="aspace_0085048ddfc5289c877d914bea60ee1b" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_bac81e2419385582ca6f17294b504f17">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_963a36e8d4a3db7247ad14c29397c947" level="file">
+          <did>
+            <unittitle>Norris, John, bookseller. 5 High Street, Lymington, Hants. To The Right Hon:
+              The Lady Mary Charlotte (Howard) Foley. Offers for sale a rare 1688 volume containing
+              a speech by Paul Foley, Speaker of the House of Commons.</unittitle>
+            <unitdate datechar="creation" normal="1891-04-02/1891-04-02" type="inclusive">1891,
+              April 2 -</unitdate>
+            <physdesc id="aspace_b408f248997d68d671f9721da46a59a1">Autograph letter 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_0cb2a4f2917e966328c6ec3e3dbbc2ad" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_48ee87f6d209bf6a693657735db73a8c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Written in third person</item>
+              <item>Foley was Speaker between 1694/5-1698</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6cff94600e53ae27f82768e7492caa8f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Lilly Library Book Department, Indiana University, Bloomington, Ind.
+                <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fae671c8145ae25edc25e3924b5e6c99" level="file">
+          <did>
+            <unittitle><persname>Higinson, Thomas Wentworth, 1823-1911, reformer.</persname>
+              Cambridge, Mass. To Franklin Benjamin Sanborn. Record of William Ellery Channing's
+              admission to Harvard.</unittitle>
+            <unitdate datechar="creation" normal="1892-03-17/1892-03-17" type="inclusive">1892,
+              March 17 -</unitdate>
+            <physdesc id="aspace_50df9efca348f249f2fcf412fef8c2ce">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_7ae2c121aa6b65440093f16551a159e6" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_c702bf05c794e6ab649ea5e2590ced01">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by: 1) Sanborn, Franklin Benjamin, Quatrain for William Ellery
+                Channing's burial urn. Autograph document 1 p. 13 cm.; 2) Channing, William Ellery.
+                Sonnet to my pipe, January 3, 1857. Copy. 1 p. 21 cm.; 3) Sanborn, Franklin
+                Benjamin. To ? October 16, 1905. Typescript letter (carbon) 1 p. 28 cm.</item>
+              <item>Removed from William Ellery Channing's <title render="italic">Poems of
+                  sixty-five years.</title> Selected and edited by Franklin Benjamin Sanborn.
+                Philadelphia and Concord, J. H. Bentley, 1902 (Lilly PS1290 .P6).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c563fad0d44a06d1f55f1c5ec1e41a1c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1954">1954.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_d4cb58824719e0933f52a47fd1a8b112" level="file">
+          <did>
+            <unittitle>Hearn. A letter to Basil Hall Chamberlain</unittitle>
+            <unitdate datechar="creation" normal="1894-06-08/1894-06-08">1894, June 8</unitdate>
+            <container id="aspace_2bb1aebcaf91c111f5cac1f556b2cfe3" label="Mixed Materials"
+              type="Bound">Bound</container>
+          </did>
+        </c02>
+        <c02 id="aspace_1620a45b06d1092fdaea9c1144f6537f" level="file">
+          <did>
+            <unittitle><persname>Dobson, Austin, 1840-1921, poet.</persname> To Charles Benjamin
+              Foote. Thanks him for records of the sale of his book collection.</unittitle>
+            <unitdate datechar="creation" normal="1895-03-16/1895-03-16" type="inclusive">1895,
+              March 16 -</unitdate>
+            <physdesc id="aspace_096cda91cb3d52fb2c1af08fc105d8a4">Card signed 1 p. 9 cm.</physdesc>
+            <container id="aspace_26a11fcd2696ece0450b4a09cffaa441" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_89f9d337d54a88507d67b96ae5545376">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on front flyleaf of C. B. Foote's <title render="italic">Catalogue of
+                  the...collection made by Charles B. Foote...sold at auction...by Bangs &amp;
+                  Co...</title> New York, 1894-1895 (Lilly Z997 .F68).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0b9fd1fd401a2eb0d91aad261397a4a7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3190b9fbe0866bd63ed64d72214e357b" level="file">
+          <did>
+            <unittitle><persname>Stevens, Benjamin Franklin, 1833-1902, bibliophile.</persname> To
+              "The Editor, The Academy." Concerns reproduction in photographic facsimile of <title
+                render="italic">The Voyage from Lisbon to India...by Albericus Vespuccius</title>
+              and a controversial twin volume <title render="italic">Americus Vespuccius...</title>
+              by Henri Harrisse.</unittitle>
+            <unitdate datechar="creation" normal="1895-04-18/1895-04-18" type="inclusive">1895,
+              April 18 -</unitdate>
+            <physdesc id="aspace_f42b4ae874ad59194841195624d3f3dc">Typescript letter signed 1 p. 26
+              cm.</physdesc>
+            <container id="aspace_bdff8cd396437ec0310c127773d0f0b1" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_a5c6eac672f1321a1edad9cc1b2e94ad">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Henry Harrisse, <title render="italic">Americus
+                  Vespuccius...</title> London, 1895 (Lilly G95 .S8 H3 Mendel).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_286a9e2459718d61ac4888af1bfbb240">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5c6ac5db19dab27948f9ab00acd506b7" level="file">
+          <did>
+            <unittitle><persname>Gunter, Archibald Clavering, 1847-1907, author.</persname>
+              Narragansett Pier, Rhode Island. To Charles Warren Stoddard. Asking Stoddard to send
+              his mss. to him.</unittitle>
+            <unitdate datechar="creation" normal="1896-08-08/1896-08-08" type="inclusive">1896,
+              August 8 -</unitdate>
+            <physdesc id="aspace_f932c9838007d12ccbf5606e50431174">Autograph letter signed 2 p. 23
+              cm.</physdesc>
+            <container id="aspace_df40b7051c42c737757c16f82cf7159f" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_5d45227d3f4648c05b4a1a7e81aa2930">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Gunter's <title render="italic">Mr. Barnes of New York...</title>
+                New York, Home Publishing Co., 1887 (Lilly PS3513 .W6 M6 copy 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_be62404884a9c252aad60832b72a888e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1958">1958</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_84765292e1978e43d1f10ba370e84d10" level="file">
+          <did>
+            <unittitle><persname>Taylor, Charles Louis, fl. 1897, editor.</persname> British Medical
+              Journal, London. To Sir D'Arcy Power. "We are getting up a Jubilee Number, and I want
+              to talk to you about it."</unittitle>
+            <unitdate datechar="creation" normal="1897-05-06/1897-06-18" type="inclusive">1897, May
+              6-June 18 -</unitdate>
+            <physdesc id="aspace_d7a5e8479daeb97d54f63f233a2a1b61">Autograph letter signed (6
+              letters) 13 cm.</physdesc>
+            <container id="aspace_7a2ea4cef6f1d3de4af7be83e63248d4" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0705326b1430a71f7ac4eba497d59370">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>May 6, 7, 13, 24; June 3, 18, 1897 mounted in <title render="italic">British
+                  Medical Journal,</title> June 19, 1897 (Lilly R31 .B9).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4d4dd5866afc7e4d3b93903be4ea3405">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0dcdfa80280557393f70739d95ad1da2" level="file">
+          <did>
+            <unittitle><persname>Tylor, Sir Edward Burnett, 1832-1917, anthropologist.</persname>
+              London. To Sir D'Arcy Power. A museum.</unittitle>
+            <unitdate datechar="creation" normal="1897-05-29/1897-05-29" type="inclusive">1897, May
+              29 -</unitdate>
+            <physdesc id="aspace_4f66a01db823d660105fe88a87b3cee1">Autograph letter signed 2 p. 17
+              cm.</physdesc>
+            <container id="aspace_13cdbdeff6e38f6a8d035d1e9021adc2" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_3efaf39216459d6023d9da034abebd1f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in <title render="italic">British Medical Journal,</title> June 19,
+                1897, between p. 1594 and 1595 (Lilly R31 .B9).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_91b9f452ddb74ee24e69af7fcbf66292">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9eeee21cd0cd3ead87002da49ae603bb" level="file">
+          <did>
+            <unittitle>Photograph of Henrik Ibsen, signed and dated.</unittitle>
+            <unitdate datechar="creation" normal="1897-07-10/1897-07-10" type="inclusive">1897, July
+              10 -</unitdate>
+            <physdesc id="aspace_d29cd881287f27b6753e2422b6f87c23">Signed 1 leaf 13 x 9.5
+              cm.</physdesc>
+            <container id="aspace_32533bf98640b5ddd1ff26a1acef22c4" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_09e773bdcaa87d3e0f1cf73cee2908c0">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on card 17 x 11 cm.</item>
+              <item>Removed from Ibsen, <title render="italic">Peer Gynt. Et dramatisk
+                  digt...</title> Kjobenhavn, F. Hegel, 1867 (Lilly PT8876 .A1 1867).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_731b2f4bcdc7a21b6420440d0566e684">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7677ee8c0845443d47431b9163e670f2" level="file">
+          <did>
+            <unittitle>Hulme, F. Edward, 1841-1909, cryptographer. To "dear sir."</unittitle>
+            <unitdate datechar="creation" normal="1897-10-01/1897-10-01" type="inclusive">1897,
+              October 1 -</unitdate>
+            <physdesc id="aspace_2c3fa0d04d27062739e403e74a3cb8f8">Autograph letter
+              signed</physdesc>
+            <container id="aspace_6b18401a099780ccb12c59bd8566ce5e" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_085cdd7ceff6550252cb9a8094dd70ae">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Hulme's <title render="italic">Cryptography; or, The history,
+                  principles, and practice of cipher-writing</title> (Lilly Z104 .H91)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6cfd672fd3ef8146677fae88c0e5d89e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Patrick King. <date normal="2006">2006.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_dd50fb710f499dfa10b6f119620d53f4" level="file">
+          <did>
+            <unittitle><persname>Ross, Sir Ronald, 1857-1932, writer, scientist.</persname>
+              Inscription to Sir William Osler. "<emph render="underline">Note.</emph> This Report
+              is not to be treated at present as being <emph render="underline"
+              >published</emph>...It...records only the lately observed facts which establish the
+              cultivability of some of the gymnosporidia in mosquitos..."</unittitle>
+            <unitdate datechar="creation" normal="1898/1898" type="inclusive">1898 -</unitdate>
+            <physdesc id="aspace_234a122b1fccd787b3a2ec3958e78263">Autograph letter signed 1 p. 31.5
+              cm.</physdesc>
+            <container id="aspace_a62e68a8fcbfc842f2f4f6765f9aa514" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_0a667516d41a1be32894893bf75383f3">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On cover of Ross, <title render="italic">Report on the cultivation of the
+                  proteosoma Labbe, in grey mosquitos,</title> Calcutta: Office of the
+                Superintendent of Government Printing, India, 1898.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e583fba833784152e392bd96fec7640e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1989">1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_48925ed96b27be553565b77cb12aa216" level="file">
+          <did>
+            <unittitle><persname>Jacobi, Charles Thomas, 1853-1933, author.</persname> Chiswick
+              Press, London. To Horace Hart. Order for india paper.</unittitle>
+            <unitdate datechar="creation" normal="1899-03-15/1899-03-15" type="inclusive">1899,
+              March 15 -</unitdate>
+            <physdesc id="aspace_d301cb97ff1bec83360f5141fc683308">Autograph letter signed 2 p. 20
+              cm.</physdesc>
+            <container id="aspace_4b5b162396e5cdccd93dc06978df3e5c" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_418d0726e3fe865dff92953d5405363a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on inside of front cover of Jacobi's <title render="italic">A Few
+                  Suggestions of Plain Letterings for Artists and Others.</title> London, Printed
+                for presentation at the Chiswick Press, 1899 (Lilly Z250 .J2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9a112496f4f2e112352d28b888dc1d6c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fd0de1907c65f89e3942e374afead122" level="file">
+          <did>
+            <unittitle>Coolidge, Mary. Actor's sides or lines for eight plays.</unittitle>
+            <unitdate datechar="creation" normal="1890/1899" type="inclusive">189- -</unitdate>
+            <physdesc id="aspace_5773dd4ef8599071bd3a4d844b7fde71">Autograph document 181 p. 13-16
+              cm.</physdesc>
+            <container id="aspace_c3d0e65b7530f15583451a1e4f9be4c8" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_8123f049b2e52d1657cf534dbd465c96">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Contents: 1) Kathleen in Kathleen Mavourneen. 44 p. 13 cm.; 2) Kitty in
+                Kathleen. Act II. 6 p. 16 cm.; 3) Dorothy Kavanagh in Kathleen Mavourneen. 7 p. 16
+                cm.; 4) Albert in Monte Cristo. Acts III &amp; IV. 13 p. 15 cm.; 5) Mercedes in
+                Monte Cristo. 12 p. 13 cm.; 6) Mary Mortimer in Naval engagements. 25 p. 14 cm.; 7)
+                Mrs. Lee in A noble outcast. 14 p. 16 cm.; 8) Daphne in Pygmalion and Galatea. 12 p.
+                14 cm.; 9) Fanny in Prologue--Ten nights. 5 p. 15 cm.; 10) Sadie. 17 p. 15 cm.; 11)
+                Unidentified. 26 p. 16 cm.</item>
+              <item>Name "Mary Coolidge" appears on the parts of Kathleen, Mercedes, and Mary
+                Mortimer</item>
+              <item>Some pages written on stationery of the Assumption Pioneer, Napoleonville,
+                Louisiana, 189-; Hotel White, Edenton, North Carolina, 1899; Turnbull's Hotel,
+                Warrenton, North Carolina, 189-; Orangeburg Hotel, Orangeburg, South Carolina,
+                189-.</item>
+              <item>Accompanied by broadside and leaflet advertising the Carew-Kinsington theatre
+                company featuring Mary and Janet Carew and managed by R. G. Kingston in "The Girl
+                from Home"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_65d1cbb0cd07da40c64d8160bcab0776">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Lawrence Wheeler, secretary, Indiana University Foundation, Bloomington,
+              Indiana. <date normal="1947">1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9df5f8d07cb5f62c5d249386b4689a2f" level="file">
+          <did>
+            <unittitle>Bible. Old Testament. Pentateuch. Hebrew. Torah.</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century?
+              -</unitdate>
+            <physdesc id="aspace_3b4b5dad65c4ce71dde7e28898770013">Autograph document 3843 x 63
+              cm.</physdesc>
+            <container id="aspace_d6a2445fcc996be418920601c4dbc42c" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_1b2446ce7e9b672e9c539325caff0dbd">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>J.D. Pearson, <title render="italic">Oriental Manuscripts in Europe and North
+                  America</title> (Switzerland, 1971), page 64 (Z6605 .O7 P37)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3b77551a823e5efe81d7c0f214faf86c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mr. and Mrs. Louis H. Silver, Hotel St. Clair, Chicago, Illinois. <date
+                normal="1958">1958.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_33e4a2fc28f5e07c2a4426080791cfb4" level="file">
+          <did>
+            <unittitle>Contemplation.</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century
+              -</unitdate>
+            <physdesc id="aspace_391a9c8a35a62c8147c74ee13198cbea">Autograph document 46 leaves 18.2
+              cm.</physdesc>
+            <container id="aspace_6f2da4f248a5a5e21f71ebd7b0a09b12" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_59f231d81cfddfd8cf13be254540406e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>"Principally written during a tour in North America"</item>
+              <item>Canto I - 40 stanzas; Canto II - 48 stanzas; Canto III (number only)</item>
+              <item>Begins: The circling year again with steady course/Renews its infant days...and
+                ends: Farewell. This book is now indeed my last,/And these bright scenes and hours
+                will be forever past</item>
+              <item>Poem commemorates the beauty and storms of nature in the New World (I-31),
+                America (I-3, II-1), Hudson River (II-8), Trenton River (II-12), Lake Erie (II-24,
+                28), Niagara (II-29, 37), the name of Washington (II-1,2), and states: But Man is
+                not my theme; again I turn/To thee sweet Nature... (II-3)</item>
+              <item>Blank leaves: 37</item>
+              <item>Watermark: J Green &amp; Son 1825</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e8bfd737e833a399c458999c1ddd6c8a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation, from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_92c6bdb6e5bacada8d657e4934ffdc6e" level="file">
+          <did>
+            <unittitle>An Ethiopian amulet or ketab in Amharic.</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century
+              -</unitdate>
+            <physdesc id="aspace_6a2d4e0e7b2e4418b87c36dddcd5186e">Autograph document 86 leaves 9 x
+              6 cm.</physdesc>
+            <container id="aspace_cd817e8adb5af69b3808f49c2ad0804c" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_1af349532323df7c7897b7856d367c33">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Probably (?) 19th century. Rubricated and with decorations and miniatures in
+                red, black and green. Contains a number of small tracts in 3 or 4 different hands
+                bound together between wooden boards, as follows:</item>
+              <item>(a) blank, f. 1: trials of the pen (fatina bere) in red and black, f.2r; a
+                charm? ff.2v-4r with a magic diagram on f.4v.</item>
+              <item>(b) Golgota (Salot), prayers of the Blessed Virgin Mary, on Mount Golgotha,
+                ff.5r-32r; blank, f.32v (only the stub of f. 32 remains)</item>
+              <item>(c) Various prayers and incantations, beginning "'Esaged lamalakoteka" and
+                ending with an invocation to the Blessed Virgin Mary, ff.334-50r, with a sketch for
+                a miniature of St George and the dragon on f.45r; a miniature of the archangels
+                Michael and Gabriel shown as the protectors of a holy Theodore (qedus Tiwoderos),
+                not further identified, on f.45v; a miniature of St. George slaying the dragon (the
+                background painted in blood) on f.50r; blank f.50v</item>
+              <item>(d) Prayers and incantations, beginning "Basam abe wawalid wamanfas kidusam" and
+                in most of which the Blessed Virgin Mary is invoked (her name has been written in
+                over an erasure in many of the rubrics towards the end), ff.51r-86v.</item>
+              <item>See Rene Basset: Les Prieres de la Vierge a Bartos et au Golgotha. Paris, 1895.
+                (Les Apocryphes ethiopiens, 5) Deborah Lifchitz: Textes ethiopiens magico-religieux.
+                Paris, 1940. (Institut d'Ethnologie. Travaux et memoires, 38) p. 15.</item>
+              <item>Accompanied by a card (5 x 8 cm.) in German. A translation follows: "Abyssinian
+                magic and prayerbook from the year ca. 800. <title render="italic">H Selata
+                  Egzitina</title>/<title render="italic">Mariam gologota</title> Prayer to the
+                Virgin Mary to be prayed in Jerusalem in addition to a few incantations (formulas of
+                magic). 86 leaves. Amhara. Acquired 1904. It is said to have been decorated with
+                human blood. The imperial royal court library wants to acquire (bids) this book for
+                900 Kcrowns. It is one of the oldest books known to date. M. R. Schmerha"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_17767b0a330b73a0d4a63e7e2061035f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Lathrop C. Harper, 8 West 40th Street, New York, New York. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1989c029aa5ab0d976afd52e09c4973a" level="file">
+          <did>
+            <unittitle>Chinese torture drawings on pith paper.</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century
+              -</unitdate>
+            <physdesc id="aspace_d3712e9742252d135f72843a370a9995">Autograph document</physdesc>
+            <container id="aspace_3822dd7871283002d97c7ef575a35419" label="mixed materials"
+              type="Box">Vault 2</container>
+          </did>
+          <scopecontent id="aspace_51dcbd8420c58d0187057e7c3089cbc7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in red cloth with tie</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c8b720f775ec6bd4dc5f2f0427ac7dbd">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Indianapolis Public Library. Indianapolis, Indiana. <date normal="1985"
+                >1985.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_821a80f6e48a718bf45395f5b6ac2a04" level="file">
+          <did>
+            <unittitle><persname>Lodge, Norman? fl. 19th century, assistant in the Science and Art
+                Department of the South Kensington Museum.</persname> To "dear Abbey." "I am awfully
+              sorry I cannot join you on the 1st. but I am in the middle of 12000 Exam
+              papers."</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century
+              -</unitdate>
+            <physdesc id="aspace_742c433eb1f58051115abeeca7593321">Autograph letter signed 2 leaves
+              19 cm.</physdesc>
+            <container id="aspace_1d61e6aee5435d49c8fa9cf469a67040" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_a3569ca327f97596d580aee164e78944">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Dated May 24</item>
+              <item>Embossed with the seal of the South Kensington Museum</item>
+              <item>Second leaf blank</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d89d221ecda7346183123e2ef4517f5e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9b8b994ac81140c36e230e1732d7c7d4" level="file">
+          <did>
+            <unittitle>Pashley, Sarah. Numeration Table.</unittitle>
+            <unitdate datechar="creation" normal="1800/1899" type="inclusive">19th century
+              -</unitdate>
+            <physdesc id="aspace_9c6885be397524f1f2a331c222f10425">Autograph document signed 30 p.
+              20 cm.</physdesc>
+            <container id="aspace_4f378ca804a136528571cec775565636" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_a08826a71aa49149203bf33f8779cc5c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Decorated with flourishes in red, green, and black ink of exotic birds and
+                people</item>
+              <item>Leaves pasted on larger pages, 27.8 cm.</item>
+              <item>Leaves enumerated in pencil: 2-10, 12-16, 18-21</item>
+              <item>Partial contents: Numeration Table, Addition of Integers, Troy Weight,
+                Averdupoize Weight, Cloath Measure, Subtraction of Integers. See Inventory for
+                complete contents</item>
+              <item>Three of the Tables bear business letters on verso dated: June 10, 1803; July 30
+                and Aug. 7, 1806 (pencilled leaves 3, 4, &amp; 10)</item>
+              <item>Sarah Pashley's name appears twice on pencilled leaf 18</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2ec9f7b770e9b8f7533fd1cc8dc18bef">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4987bf01d1405bbab41e60ae527d9a91" level="file">
+          <did>
+            <unittitle>Santa Rosa Teacher's Club mimeographed discussion questions.</unittitle>
+            <unitdate datechar="creation" normal="1901-10-22/1901-12-03" type="inclusive">1901,
+              October 22-December 3 -</unitdate>
+            <physdesc id="aspace_45971aeac59f1657ca2bc34de0f9f758">Typescript 4 leaves</physdesc>
+            <container id="aspace_0eb6f6b14715f43fba983f6211f80394" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_3ac4c60c63ee9cf618ada370aa3730f8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from John Dewey, <title render="italic">The school and
+                  society...</title> Chicago: University of Chicago Press, 1899 (Lilly LB875
+                .D395).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f00d0ea98ec4e6f08af67d8f17025720">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1986">1986.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_93b8b4383613e9d1c97c45936f413346" level="file">
+          <did>
+            <unittitle><persname>Parrish, Maxfield, 1870-1966, artist.</persname> Windsor, Vermont.
+              To R. Harold Paget. Acknowledges three copies of <title render="italic">Dream
+                Days.</title> "I think you have made a very attractive book of it. The cover design
+              was done under protest, for I don't like the kind of cover Mr. Lane likes, but the
+              inside is very attractive."</unittitle>
+            <unitdate datechar="creation" normal="1902-10-06/1902-10-06" type="inclusive">1902,
+              October 6 -</unitdate>
+            <physdesc id="aspace_fd378cdcb9b3bf865432a14df9672b06">Autograph letter signed 1 p. 26
+              cm.</physdesc>
+            <container id="aspace_584ca286097178b63bb2e98e20901481" label="box" type="box"
+              >6</container>
+          </did>
+          <acqinfo id="aspace_eaa83edf5771c13334b5545f2c7e54e2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hants, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c9c413dcbe85946806db39a840f64906" level="file">
+          <did>
+            <unittitle>Berwick, Maria del Rosario, duquesa de, 1845-1904. Madrid, Spain. To Henry
+              Harrisse. Thanking him for his "Apocrifos Americanos."</unittitle>
+            <unitdate datechar="creation" normal="1903-06-25/1903-06-25" type="inclusive">1903, June
+              25 -</unitdate>
+            <physdesc id="aspace_1175abb3ddc3c0b0a96bdac505142b98">Typescript letter signed 3 p. 14
+              cm.</physdesc>
+            <container id="aspace_66b216d8bc236bf81aaa690ee8a499ca" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_22672ae955ae7b5b27281ee7050571fa">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Appended note in Harrisse's hand</item>
+              <item>Mounted on half-title of Jose Gestoso y Perez's <title render="italic">Nuevos
+                  documentos Colombinos...</title> Sevilla, 1902 (Lilly E114 .G39).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_bba87588d739ef464c5e90600b496709">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_28990cc1defcf4dba1ebe857f95a0da2" level="file">
+          <did>
+            <unittitle><persname>Power, Sir D'Arcy, 1855-1941, surgeon.</persname> 10A Chandos
+              Street, Cavendish Square W, London, England. To James Murphy, Esq., The Glasgow
+              Verterinary College, Glasgow, Scotland. "...I should have very litte doubt that the
+              notes, as you suppose, were actually written by Harvey. The edition of Fabricius is
+              not I think very uncommon..."</unittitle>
+            <unitdate datechar="creation" normal="1903-07-10/1903-07-10" type="inclusive">1903, July
+              10 -</unitdate>
+            <physdesc id="aspace_86ed54b38e7d7a804725d624b997f99d">Typescript letter signed 1 leaf
+              25 cm.</physdesc>
+            <container id="aspace_e99fe2ef734f903f7882c0dda9653dec" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_7a1978208439a700379667ab0d305b8e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>A holograph note in ink states: "I thought you would not mind my keeping a set
+                of the photos. D'aP."</item>
+              <item>Removed from Hieronymous Fabricius, ab Aquapendente, <title render="italic"
+                  >Opera physica anatomica...</title> Padua, Sumptibus Roberti Migletti, 1625 (Lilly
+                QM5 .F12 A2 1625).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_59a6324a862f180bc7996345fcf94cf1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_91cf8e17004bc913bd2b9da9fc5d8b63" level="file">
+          <did>
+            <unittitle><persname>Payne, Joseph Frank, 1840-1910, physician.</persname> 78 Wimpole
+              Street, Cavendish Square W, London, England. To Dr. James Murphy, The Glasgow
+              Veterinary College, Glasgow, Scotland. "I am extremely obliged to you for sending me
+              your photographs of Harvey's notes in a copy of Fabricius."</unittitle>
+            <unitdate datechar="creation" normal="1903-07-20/1903-07-20" type="inclusive">1903, July
+              20 -</unitdate>
+            <physdesc id="aspace_1355142890ea1e1e07268febeb73dd68">Autograph letter signed 4 p. 18 x
+              11 cm.</physdesc>
+            <container id="aspace_7f4501f73b7aeb2a2c8d2a2fd0b06762" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_81c5529a1b3fc585c65d3ed33dc49ae4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In black ink</item>
+              <item>Page reference to Fabricius in pencil</item>
+              <item>Removed from Hieronymus Fabricius, ab Aquapendente, <title render="italic">Opera
+                  physica anatomica...</title> Padua, Sumptibus Roberti Migletti, 1625 (Lilly QM5
+                .F12 A2 1625).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6b96f5da50be7123b80e0bcebb467c9a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1f7fa0dc22e85e070dd632c6acd734ba" level="file">
+          <did>
+            <unittitle><persname>McGirr, Newman F., 1877-1952, antiquary, librarian.</persname>
+              Franklin Book Shop, 1105 Walnut St., Philadelphia, PA. To Luella Agnes Owen. Sending
+              Say's American Conchology while conducting the book business in the absense of Samuel
+              Rhoads away on a collecting trip.</unittitle>
+            <unitdate datechar="creation" normal="1905-02-14/1905-02-14" type="inclusive">1905,
+              February 14 -</unitdate>
+            <physdesc id="aspace_261d16f0c84a92e94b6243796e1bb1e9">Autograph letter signed 2 p. 13.5
+              cm.</physdesc>
+            <container id="aspace_9083c78a7abf4437bf66cd24bd825859" label="box" type="box"
+              >6</container>
+          </did>
+          <scopecontent id="aspace_1d2bc7dc5706f6dd9ea152a86e20fd65">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Volume from which letter was removed bears several signed notations in the hand
+                of L.A. Owen with reference to Professor Louis Pope Gratacap</item>
+              <item>Removed from Thomas Say, <title render="italic">American Conchology...</title>
+                New Harmony, Indiana. Printed at the School Press, 1830 (Lilly QL411 .S2 copy
+                2)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_502fe79b2546225cbd9b9be702ecf1c9">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1979">1979.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_842f50b9e62629f048025a6585b2ce76" level="file">
+          <did>
+            <unittitle><persname>Osler, Sir William, bart., 1849-1919, physician.</persname>
+              University Club, Fifth Avenue &amp; 54th Street, New York, New York. To Charles
+              Phillips, Emerson. Johns Hopkins Hospital, Baltimore, Maryland. "I enclose the
+              introduction...add anything you wish."</unittitle>
+            <unitdate datechar="creation" normal="1906-02-02/1906-02-02" type="inclusive">1906,
+              February 2 -</unitdate>
+            <physdesc id="aspace_58b04a50124ff509193e5d0daf881aa4">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_6ccb03bc2e9bdcf980032a8b06c23c3f" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_23fdf85281accd6ed1bfc08b31c0b71a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_bc97a99e239401c3840cbabefc059b26">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d6946a8a14e1e431cfbf91fb1f89a1e1" level="file">
+          <did>
+            <unittitle><persname>Hart, Charles Henry, 1847-1918, author.</persname> To "Dear
+              Benjamin." Refers to autograph lists.</unittitle>
+            <unitdate datechar="creation" normal="1906-02-12/1906-02-12" type="inclusive">1902,
+              February 12 -</unitdate>
+            <physdesc id="aspace_0046f69c07356ae0147f583ca9b4c602">Facsimile of autograph letter
+              signed 1 p. 22 cm.</physdesc>
+            <container id="aspace_e1b951116c7680d357770f5fb48f6d1a" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_943e891e754edfef6efa2ebc3ed0f7a6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Hart's <title render="italic">Catalogue of the engraved portraits
+                  of Washington.</title> New York, The Grolier Club, 1904. (Lilly E321.4 .H3)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_608d2f56241a3215285d5018782bbd6e">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Arthur Mitten, Goodland, Indiana, and Philadelphia, Pennsylvania.
+                <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fd8f4db79dde685eb2cbdc97a39e24a6" level="file">
+          <did>
+            <unittitle><persname>Haebler, Konrad, 1857-1946, bibliographer.</persname> To ? Refers
+              to the copy of Rodericus Vassartus, Additamentum...in the Biblioteca
+              Nacional.</unittitle>
+            <unitdate datechar="creation" normal="1906-05-21/1906-05-21" type="inclusive">1906, May
+              21 -</unitdate>
+            <physdesc id="aspace_1e9cb85e7d93e1040d62688dd609ce68">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_d3a7f2253efd431fc6160842a8794fc6" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_08b64a14359b0bfef8f29ef29a0e4fe9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in at front of Rodericus Vassurtus, <title render="italic">Additamentum
+                  ad Calendarium Johannis de Monteregio.</title> Salamanca, Leonard Hutz and Lupus
+                Sanz, about 1497 (Lilly QB85 .V34 1497)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ae0d6a9a64dcf85d9631fa1d08150225">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f16e5226c639ad6fbc9cfd36ba4950b3" level="file">
+          <did>
+            <unittitle><persname>Osler, Sir William, bart., 1849-1919, physician.</persname> From
+              the Regius Professor of Medicine, Oxford, England. To Charles Phillips Emerson. Johns
+              Hopkins Hospital, Baltimore, Maryland, U.S.A. "The photographs and the plate
+              came."</unittitle>
+            <unitdate datechar="creation" normal="1907-04-06/1907-04-06" type="inclusive">1907,
+              April 6 -</unitdate>
+            <physdesc id="aspace_01c6f57e092ab4bdd9f152bd54329d6b">Typescript letter signed 1 p. 11
+              cm.</physdesc>
+            <container id="aspace_7edfc57ad93f8749ae3c09f9f37efaa9" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_ebf8c941f72a5de0d22448cc956187d2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c2df5a5f5be482b79c666e236a7d7bef">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ed0c1d86c60996276fb7b0debb06d122" level="file">
+          <did>
+            <unittitle>King, Mackenzie. To Reid, Harriet and T.L.Lewis Esq., President United Mine
+              Workers of America, Indianapolis, Ind.</unittitle>
+            <unitdate datechar="creation" normal="1908-06-25/1908-06-25" type="inclusive">1908, June
+              25 -</unitdate>
+            <physdesc id="aspace_93a5aef2c5e81a87ba3fb92fb667296c">Typescript letter signed 2
+              p.</physdesc>
+            <container id="aspace_13126683607eaa547c80c82fce386eaf" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_849f6746b7854a8fc85ddcad0dc2a024">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On Department of Labour - Canada - Office of the Deputy Minister
+                stationery</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_322505b55c4de13a6abca7fa0677aab1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_181ba0b6b03b1287cd310033c375f737" level="file">
+          <did>
+            <unittitle>Goldschmidt, Ernst Philip. Notes on the books of Charles Henry Comte de Hoym.
+              1694-1736. by Ernst Ph. Goldschmidt begun in Cambridge</unittitle>
+            <origination audience="internal" label="Creator"><persname>Goldschmidt, E. Ph. (Ernst
+                Philip)</persname></origination>
+            <unitdate datechar="creation" normal="1909-06-07/1909-06-07">June 7th 1909.</unitdate>
+            <physloc audience="internal" id="aspace_838161d1b9d2b4160372f0be1f237b5f">Lilly -
+              Stacks. Spine reads "Notes on De Hoym Books."</physloc>
+            <container id="aspace_4db3faba33233c6d5f401bcf8004dcae" label="bound" type="Bound"
+              >Bound</container>
+          </did>
+          <acqinfo audience="internal" id="aspace_22568588e8a2b8ad88477163ec058b14">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase: 2000. Jonathan A. Hill, Bookseller.</p>
+          </acqinfo>
+          <controlaccess>
+            <subject authfilenumber="sh85013838" source="lcsh">Bibliography</subject>
+            <persname audience="internal">Goldschmidt, E. Ph. (Ernst Philip)</persname>
+            <persname audience="internal">Hoym, Karl Heinrich, Graf von, 1694-1736</persname>
+          </controlaccess>
+        </c02>
+        <c02 id="aspace_2195cc0fd1cb770f99cd76de6b0a3e86" level="file">
+          <did>
+            <unittitle><persname>Bryce, James Bryce, viscount, 1838-1922, diplomat.</persname>
+              British Embassy, Washington, D.C. To the John McBride Company, 2 Rector Street, New
+              York, New York. Expresses thanks for a copy of <title render="italic">Bradford's
+                History of the Plymouth Settlement.</title></unittitle>
+            <unitdate datechar="creation" normal="1909-11-16/1909-11-16" type="inclusive">1909,
+              November 16 -</unitdate>
+            <physdesc id="aspace_eca0541f15ac18c748a1080d193a0e40">Typescript letter signed 1 p. 27
+              cm.</physdesc>
+            <container id="aspace_34df28d2458eefce4f1d22ad0a48dc27" label="box" type="box"
+              >7</container>
+          </did>
+          <acqinfo id="aspace_1790cfd870afbe59089d0a4e030a7cef">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hants, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ebbbe889b91a17414f49bcf448133e37" level="file">
+          <did>
+            <unittitle><persname>Fison, Sir Frederick, 1847-1927, bart.</persname> Note about George
+              Waring, who married Charlotte, the half-sister of his father, William Fison, and
+              Waring's work at Bodleian Library.</unittitle>
+            <unitdate datechar="creation" normal="1909-12-25/1909-12-25" type="inclusive">1909,
+              December 25 -</unitdate>
+            <physdesc id="aspace_cecbf3de8db86ac185bf8773bb292ebc">Autrograph note signed 1 p. 28
+              cm.</physdesc>
+            <container id="aspace_59c785ac6cba22d9224e777f42466cc5" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_2be146691b914c1afbfca0db12cd85e2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Written on the first blank page of Bosworth, ed., <title render="italic">The
+                  Gothic and Anglo-Saxon Gospel in Parallel Columns, with the Versions of Wycliffe
+                  and Tyndale.</title> London, John Russell Smith, 1865 (Lilly BS2549 .A4
+                1865).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6956d2f5d3b13aecc3edd0993950cf66">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_af7c632a7d6638c456ef252af2089003" level="file">
+          <did>
+            <unittitle><persname>Bryce, James Bryce, viscount, 1838-1922, diplomat.</persname>
+              British Embassy, Washington, D.C. To R. Harold Paget, 2 Rector Street, New York City.
+              "I shall be happy to see you for a few minutes on the 13th..."</unittitle>
+            <unitdate datechar="creation" normal="1910-04-09/1910-04-09" type="inclusive">1910,
+              April 9 -</unitdate>
+            <physdesc id="aspace_e46ff969f9c489ee44ba1f23728c93e1">Typescript letter signed 1 p. 27
+              cm.</physdesc>
+            <container id="aspace_f1503de113025e796cc35001bc6edcf2" label="box" type="box"
+              >7</container>
+          </did>
+          <acqinfo id="aspace_c74570ccdb0c2a4ff35e0ba8d53e5826">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 105 Southampton Road, Ringwood, Hantz, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0518655d4367fdc0e208d518b599f11e" level="file">
+          <did>
+            <unittitle>Abbey Theatre. Salary book.</unittitle>
+            <unitdate datechar="creation" normal="1910-03-04/1912-09-20" type="inclusive">1910,
+              March 4-1912, September 20 -</unitdate>
+            <physdesc id="aspace_8cc00dca298f290a973e53fd828b4517">Autograph document 137 leaves 21
+              cm.</physdesc>
+            <container id="aspace_3460e8ab7c7bb93bbee15dbcf668c28b" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_c71ce33d8c9a6ec87c105b47593ee9a7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bound in black cloth with roan shelfback, spine imperfect</item>
+              <item>Bookplate for Hely's, Limited, on front pastedown</item>
+              <item>"National Theatre Society" stamped in blue ink at top of first 13 leaves</item>
+              <item>1 folded leaf laid in between leaves 125-126</item>
+              <item>Accounts written in several hands, one of which may be that of Lennox
+                Robinson</item>
+              <item>Salary entries include those of Sara Allgood, Joseph M. Kerrigan, Fred
+                O'Donovan, Maire O'Neill, Lennox Robinson, and Arthur Sinclair</item>
+              <item>On leaf 136r. are entries for loans to W. B. Yeats</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c141cf2eedf1d3c6d832c64944885c93">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Figgis Rare Books Ltd., Dublin, Ireland. <date normal="1989"
+              >1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bcdfecd3a6092052a6199dd15a53aea8" level="file">
+          <did>
+            <unittitle>Rubaiyat of Omar Khayyam. Written by Helen A. Wingate. Edinburgh.</unittitle>
+            <unitdate datechar="creation" normal="1911/1911" type="inclusive">1911 -</unitdate>
+            <physdesc id="aspace_05c3052926f559dcd47a3e3f2c067822">Autograph document signed 42 p.
+              19.5 cm.</physdesc>
+            <container id="aspace_c4a893ab6a29d5df7adb0999bab71f98" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_b37b25ab608afc1329804baaf0ce949f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In brown leather covers with gold tooling</item>
+              <item>Selection of 75 quatrains (not Fitzgerald translation)</item>
+              <item>Illuminated in gold, red, blue and green with birds, animals and flowers</item>
+              <item>On vellum</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1e005540329e0a69de0893630311eaba">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1f292a9c65f436b7d35729e80b2a676a" level="file">
+          <did>
+            <unittitle>Jones, D. A., assistant librarian, Royal Geographical Society, 1, Savile Row,
+              Burlington Gardens, London, W. To Robert Hewitt, esq. Encloses the formal
+              acknowledgement of the receipt of Hewitt's work on Coffee and goes into the technical
+              aspects of folding a map.</unittitle>
+            <unitdate datechar="creation" normal="1912-09-05/1912-09-05" type="inclusive">1912,
+              September 5 -</unitdate>
+            <physdesc id="aspace_0815564a0e6648938c1c2e78dff6ee3a">Autograph letter signed 2 p. 17.8
+              cm.</physdesc>
+            <container id="aspace_199a5fcd190be76e7f92723f75610bf0" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_664f83e084c9fab061bcecf93846c132">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Enclosure: Printed acknowledgement filled in with the title of the book
+                received, dated 5th September 1912, to Robert Hewitt, Esq. 1 p. 23.5 cm.</item>
+              <item>Removed from Hewitt, <title render="italic">Coffee: its history, cultivation,
+                  and uses.</title> New York, D. Appleton and Co., 1872 (Lilly SB269 .H611
+                C67).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4834ce76befef761cdd57ad503548464">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1980">1980.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5628ce8d282f8a39265cb38c55ddb670" level="file">
+          <did>
+            <unittitle>Mascart, Jean. Letter to "Lieber freund und Collegue."</unittitle>
+            <unitdate datechar="creation" normal="1912-09-18/1912-09-18" type="inclusive">1912,
+              September 18 -</unitdate>
+            <physdesc id="aspace_52c9efb03eaa44a37bf7ae1fbf001faf">Autograph letter signed 2
+              p.</physdesc>
+            <container id="aspace_a0c718f7f5a9a594cdda2a2a23e926d8" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_80d4550fa3c1ea37b001baf8e89d51e6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by menu autographed by members of an Association internationale
+                contra la tuberculose expedition.</item>
+              <item>Removed from Mascart, <title render="italic">Impressions et observations dans un
+                  voyage a Tenerife.</title> Paris: Ernest Flammarion, 1912? (Lilly Q115 .M4)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_11f398c2d524a5ee7aa1e568160c2d16">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1986">1986.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0d6292009b61f12874888ac6ea684a05" level="file">
+          <did>
+            <unittitle><persname>Dewick, Edward Samuel, 1844-1917, clergyman.</persname> 26 Oxford
+              Square Hyde Park. To George Claridge Druce. Wimbledon, Surrey. Is pleased to send a
+              P.O. for 10/- as a contribution to a parting gift for Mr. Sheath.</unittitle>
+            <unitdate datechar="creation" normal="1913-01-09/1913-01-09" type="inclusive">1913,
+              January 9 -</unitdate>
+            <physdesc id="aspace_979ac2c170c7b951e701504dc8f4b242">Autograph letter signed 2 p. 17.7
+              cm.</physdesc>
+            <container id="aspace_3f8c34b65317b04e65bc9095be171424" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_b0ed138a801d5fe7f6d18a341ae0b95c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Mourning stationery</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a25b6a841b9dd126440d0f248c026239">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Julia (Ricketts) King and Jasper King, Jr. Evanston, Ill. <date normal="1989"
+                >1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7781aec362edf573c1e73469c8c4d043" level="file">
+          <did>
+            <unittitle><persname>Eckart, Dietrich, 1868-1923, poet, playwright.</persname> Bad
+              Blankenburg, Thuringen. To Perbandt. Unable to help Perbandt now, but it may be
+              otherwise in November when he will be in Berlin.</unittitle>
+            <unitdate datechar="creation" normal="1913-10-24/1913-10-24" type="inclusive">1913,
+              October 24 -</unitdate>
+            <physdesc id="aspace_7d6707c33edc058a63a56474c58fdb59">Autograph letter signed 1 p. 17.7
+              cm.</physdesc>
+            <container id="aspace_d9de4672a49c420c2f00431ccefc8dbd" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_ccaac2df28fc5bc18f47991890251dc7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In German</item>
+              <item>In green slipcase</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b3a27c197ec5c5f1febf0e88d42d180e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Edward Percy Rich, Oak Park, Illinois. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b46b891edee34bddfdc0c72ef1b4cd9a" level="file">
+          <did>
+            <unittitle><persname>Wellcome, Sir Henry Solomon, 1853-1936, chemist.</persname> 54A,
+              Wigmore Street, London, W. England. To James Murphy Esq., 52, Rose Street, Garnethill,
+              Glasgow, Scotland. "I am returning to-day the object you so kindly lent for the
+              Historical Medical Museum..." Form letter, initialed by secretary.</unittitle>
+            <unitdate datechar="creation" normal="1913-11-06/1913-11-06" type="inclusive">1913,
+              November 6 -</unitdate>
+            <physdesc id="aspace_754c342332567d78c304cae56cd7eb93">Typescript (copy) 1 leaf 26
+              cm.</physdesc>
+            <container id="aspace_1653ab2b0416228ce760a5af5c70e884" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_b6d750465b20f098407bbf140e477ca4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Secretary's initials: C.S.T.</item>
+              <item>With emendations in ink</item>
+              <item>At head of stationery: The Welcome Historical Medical Museum</item>
+              <item>The object referred to in the letter was a copy of the works of Fabricius with
+                holograph notes by William Harvey.</item>
+              <item>Removed from Hieronymus, Fabricius, ab Aquapendente, <title render="italic"
+                  >Opera physica anatomica...</title> Padua, Sumptibus Roberti Migletti, 1625 (lilly
+                QM5 .F12 A2 1625).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_5f80d0f9956525814d0bbea2745068b4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fe4bebf4a18c09438a313335239d4591" level="file">
+          <did>
+            <unittitle><persname>Wellcome, SJir Henry Solomon, 1853-1936, chemist.</persname> 54A,
+              Wigmore St., London, W. England. To James Murphy. "...I should therefore be glad to
+              know if you would be willing to allow the objects you have been good enough to lend,
+              to remain as a permanent loan..." Form letter with facsimile signature.</unittitle>
+            <unitdate datechar="creation" normal="1913/1913" type="inclusive">1913 -</unitdate>
+            <physdesc id="aspace_ca78a6254198123bc92eeecf6759d2f6">Typescript (copy) 1 leaf 25
+              cm.</physdesc>
+            <container id="aspace_0cadf608d88aefc04cc4d9d62a651fca" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_6928fb2db9ed088e57098a1715dd38ca">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>At the head of stationery: Historical Medical Museum.</item>
+              <item>The object referred to in the letter is a copy of the works of Fabricius with
+                holograph notes by William Harvey.</item>
+              <item>Removed from Hieronymus, Fabricius, ab Aquapendente, <title render="italic"
+                  >Opera physica anatomica...</title> Padua, Sumptibus Roberti Migletti, 1625 (lilly
+                QM5 .F12 A2 1625).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7d0b09541b1c08da0b8ecad063334862">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a7995c7f717d397041e86d59990fd53a" level="file">
+          <did>
+            <unittitle><persname>Garabed der Sahaghian, P., 1882-1914, author.</persname> Venise,
+              Italy. To Edouard Jean Marie Champion? Thanks for interest in essay on "Itineraire;"
+              possibility of translation.</unittitle>
+            <unitdate datechar="creation" normal="1914-03-15/1914-03-15" type="inclusive">1914,
+              March 15 -</unitdate>
+            <physdesc id="aspace_99033a37390f544ea7cf86ef8ac43ed9">Autograph letter signed 3 p. 18
+              cm.</physdesc>
+            <container id="aspace_bbd52139c18a7a66726524b959cca35d" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_89a888a44f2a15113cd1a11a3fece9de">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from P. Garabed der Sahaghian, <title render="italic">Chateaubriand en
+                  Orient.</title> Venice, 1914 (PQ2205 .Z5 G19).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_baf983a7cf470bdce2db7130457c137d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1951">1951.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_dd8cf611afe9b4239a7632190865b9b1" level="file">
+          <did>
+            <unittitle><persname>Garabed der Sahaghian, P., 1882-1914, author.</persname>
+              Constantinople. To Edouard Jean Marie Champion, Paris. Thanks for sending article by
+              Demaison.</unittitle>
+            <unitdate datechar="creation" normal="1914-04-06/1914-04-06" type="inclusive">1914,
+              April 6 -</unitdate>
+            <physdesc id="aspace_6efc4218412c32e33ac0b15e448d1a35">Autograph postcard signed 1 p. 9
+              x 14 cm.</physdesc>
+            <container id="aspace_937e08a2725e12f37a611f87cc49e0c6" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_2ec8b39bdb604e0fde63d4003f4ba099">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from P. Garabed der Sahaghian, <title render="italic">Chateaubriand en
+                  Orient.</title> Venice, 1914 (PQ2205 .Z5 G19).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ef42f063a3648c4a16a9a3ff2ed5651e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1951">1951.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_241c01a900720035a2c6e0062070a26a" level="file">
+          <did>
+            <unittitle>'Noh' or Accomplishment. A Study of the Classical Stage of Japan, by
+              Fenollosa and Pound</unittitle>
+            <unitdate datechar="creation" normal="1916-09-18/1916-09-18">1916, September
+              18</unitdate>
+            <container id="aspace_2df8e97006d86081525d7486486c61de" label="Mixed Materials"
+              type="Box">16</container>
+          </did>
+        </c02>
+        <c02 id="aspace_cb2f8db9edaeef28ff1d9fc35de44d6a" level="file">
+          <did>
+            <unittitle><persname>Bryce, James Bryce, viscount, 1838-1922, diplomat.</persname> To
+              stephen Vincent Benet. Thanks him "for the University Prize Poem."</unittitle>
+            <unitdate datechar="creation" normal="1917-11-06/1917-11-06" type="inclusive">1917,
+              November 6 -</unitdate>
+            <physdesc id="aspace_55dba8bec04a1e9a3ba53a048a9477b7">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_02f2dc937c408fe27bb650bab7c4b207" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_a5e10f38926814379cbff34a160eba2b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on inside of back cover of Benet's <title render="italic">The drug-shop,
+                  or Endymion in Edmonstown...</title> New Haven, Yale University Press, 1917 (Lilly
+                PS3503 .E5 D7).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1d1d4c04b0ba700e1c0e658d0589a17c">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b0fa311a18a63731a08c08de227d9ad0" level="file">
+          <did>
+            <unittitle>Pius XI, pope, 1857-1939. To Selatie Edgar Stout. Granting permission to him
+              to have a photographic copy made of a manuscript of Pliny's letters in the Vatican
+              Library to serve "solely for study and not for example for reproduction."</unittitle>
+            <unitdate datechar="creation" normal="1918-01-23/1918-01-23" type="inclusive">1918,
+              January 23 -</unitdate>
+            <physdesc id="aspace_8221c6ecb63ba840f2d7a4aff87d93b1">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_88e1a3fe392a2046f1347ccad7973d86" label="box" type="box"
+              >7</container>
+          </did>
+          <acqinfo id="aspace_a47447056dd2de2f35ee221181ec3a46">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Selatie Edgar Stout, Indiana University, Bloomington, Indiana. <date
+                normal="1930">1930.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6cdfea77418592ffa207b6cfaf401345" level="file">
+          <did>
+            <unittitle><persname>Omar Khayyam, ca. 1024-ca. 1123, poet.</persname> Omar Khayyam:
+              English translation of verse beginning, "Let not your soul in Sorrow's clasp be prest"
+              by Eben Francis Thompson. Illuminated by Harold H.R. Thompson.</unittitle>
+            <unitdate datechar="creation" normal="1919-10-10/1919-10-10" type="inclusive">1919,
+              October 10 -</unitdate>
+            <physdesc id="aspace_7335f454220fc7fa5ece84394803ee18">Illuminated document 1 p. 18 x 31
+              cm.</physdesc>
+            <container id="aspace_0a9e04ad803649312fb4ea2d1c42f93b" label="box" type="box"
+              >7</container>
+          </did>
+          <acqinfo id="aspace_306a06770d9a7049e08bdf4a451b1490">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. George Ball estate, Muncie, Indiana. <date normal="1965">1965.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_eefc1815a5e24a39f073960c2b4d0d3e" level="file">
+          <did>
+            <unittitle>Bessery, Théodore. Lavaur, France. To Gaston Tournier. Disturbance in Lavaur
+              over burial of Claud Cabanis, a Protestant, in 1749.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">4 autograph
+                letters signed 11 p. 18-27 cm.</extent></physdesc>
+            <unitdate datechar="creation" normal="1921-06-22/1926-04-09" type="inclusive">1921, June
+              22-1926, April 9 -</unitdate>
+            <container id="aspace_23e4a5f467e6fa6da5e77efeb2402508" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_75b596cce4084342a3985d2e7d580269">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In answer to inquiries for material for Gaston Tournier. "Une grave émeute a
+                Lavour a l'occasion de l'inhumation d'un protestant (1749)." Société de l'historie
+                du Protestantisme français. <title render="italic">Bulletin,</title> LXXV: 48-59,
+                Jan.-Mar. 1926.</item>
+              <item>Removed from Société de l'histoire du Protestantisme Français. <title
+                  render="italic">Bulletin,</title> vol. 74, 1925 (BX9450 .S67).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a06bf309fb58e1fe8ff21dca14313834">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bda6f8696cd262b46baca2c338c25f04" level="file">
+          <did>
+            <unittitle><persname>Ritter, Eugène, 1836-1928, author.</persname> Geneva, Switzerland.
+              To Louis Thomas, Paris, France. Regarding identification of Charles Mounard mentioned
+              in a letter of Chateaubriand.</unittitle>
+            <unitdate datechar="creation" normal="1922-02-03/1922-02-03" type="inclusive">1922,
+              February 3 -</unitdate>
+            <physdesc id="aspace_01414d5e8251f8bf5cdaa4908ba122f9">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_1595fb18649785347c5fc686f59edbdc" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_c6cb6dde87b61442323e0b91b21c6ce1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Removed from <title render="italic">Le Cinquantenaire des Funérailles de
+                  Chateaubriand célébré à Saint-Malo et à Combour les 7 et 8 Aout 1896.</title>
+                Nantes, Société des Bibliophiles Bretons et de l'Histoire de Bretagne, 1899 (PQ2205
+                .Z5 C57).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_db759dad3cf782ce712ef698b309a8c4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1951">1951.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f23d7b5301e812f2400d5f29c5a4dbff" level="file">
+          <did>
+            <unittitle><persname>Wardrop, Sir John Oliver, 1864-1948, consul general.</persname> 27
+              rue Erckmann-Chatrain, Strasbourg, France. To J. J. Cotton. Salisbury Hotel,
+              Folkestone, Angleterre. Personal letter about the family and mutual
+              friends.</unittitle>
+            <unitdate datechar="creation" normal="1923-11-08/1923-11-08" type="inclusive">1923,
+              November 8 -</unitdate>
+            <physdesc id="aspace_e5fe0700eb6031d05028af06a28d1b1a">Autograph letter signed 4 p. 17
+              cm.</physdesc>
+            <container id="aspace_c33dc458dd7822a79dae79db38ff60b6" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_5efe7f3b9c1190e9e1896c4cca65771c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Removed from Sulkhan-Saba Orbeliani's <title render="italic">The book of wisdom
+                  and lies.</title> Hammersmith, Middlesex. Printed by William Morris at the
+                Kelmscott Press, 1894 (Lilly PK9169 .O7 B5).</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_37c402344695aea8a274a3165640ad63">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6d10758953b9e7866ac34835dbc99602" level="file">
+          <did>
+            <unittitle><persname>Kallas, Aino (Krohn), 1878-1956, author.</persname> Calling card of
+              Madame Oskar Kallas, bearing the inscription "With kind regards."</unittitle>
+            <unitdate datechar="creation" normal="1924-05-14/1924-05-14" type="inclusive">1924, May
+              14 -</unitdate>
+            <physdesc id="aspace_60459cc275069d26201b3a2a82a067dc">Autograph card 1 leaf 4.8 x 7.5
+              cm.</physdesc>
+            <container id="aspace_e88764fa981a0e60027667c2cc05e8f5" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_51ff8e8c02804de33b6f92088bd9dda9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Address in lower left corner: 167, Queen's Gate, S.W.7</item>
+              <item>Removed from Aino (Krohn) Kallas, <title render="italic">The White
+                  Ship...</title> London, Jonathan Cape, 1924 (Lilly PH355 .K3 W58).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cc8db8d28c64adce05cd6fd15c28ad64">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_65357efaca113bac4b13ae143ad33934" level="file">
+          <did>
+            <unittitle>Law, Alice, author. The old parsonage, Altham, Accrington, Lanca. To Dr.
+              Haswell. Thanks him for his photograph; her photograph.</unittitle>
+            <unitdate datechar="creation" normal="1924-07-25/1924-07-25" type="inclusive">1924, July
+              25 -</unitdate>
+            <physdesc id="aspace_c0d5f0b1ece9d92df1feaad763efad6b">Autograph letter signed 2 p. 17
+              cm.</physdesc>
+            <container id="aspace_edffb4e08bd815c96a10144bb9a311e9" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_55adc37c1afb381132801c426d22cde7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by photograph of Alice Law, inscribed "Alice Law. (in 1912-)"</item>
+              <item>Removed from Alice Law's <title render="italic">Patrick Bramwell</title>
+                Bronte...London, A.M. Philpot, 1923 (Lilly PR4174 .B2 L3)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_23734eb3bcd41469a20149a00e0321d2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1964">1964.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9e87675aa20bdd0355f972b55bd10a52" level="file">
+          <did>
+            <unittitle><persname>Updike, Daniel Berkeley, 1860-1941, printer.</persname> Heath,
+              Mass. To Walter Prichard Eaton. Eaton's article on printers in the <title
+                render="italic">Bookman</title>; his press.</unittitle>
+            <unitdate datechar="creation" normal="1924-08-09/1924-08-09" type="inclusive">1924,
+              August 9 -</unitdate>
+            <physdesc id="aspace_2dd27eeeb1b00d09c5df4d31c6a5544e">Autograph letter signed 5 p. 21
+              cm.</physdesc>
+            <container id="aspace_cba051e3b9c87b26cf782754fe259faa" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_7fb740c1cb47870cb577ee4417187efe">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by cover</item>
+              <item>Removed from Updike's <title render="italic">Printing Types...</title>
+                Cambridge, Harvard University Press, 1922 (Lilly Z250 .A2 U66 vol. 1).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f570b6503692171eb3631bad38ddc8a1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3636c5db616f4f3080fca36e02a77f51" level="file">
+          <did>
+            <unittitle><persname>Hense, Wilhelm, fl. 1924, author.</persname> The German
+              Consolidated Newspaper Co. Publishers of <title render="italic">Wachter und
+                Anzeiger</title> Oregon &amp; East 12th Street, Cleveland, Ohio. To George Alexander
+              Ball, Oakhurst, Muncie, Indiana. "I mail you an Omar booklet, just published by me. If
+              you wish...to keep it, kindly send $1.00."</unittitle>
+            <unitdate datechar="creation" normal="1924-08-28/1924-08-28" type="inclusive">1924,
+              August 28 -</unitdate>
+            <physdesc id="aspace_eb8b112dee7c3709213e19ce6e0d35c5">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_a1074fb65d47dd7a71f7d5e80b2a56f2" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_6d963e5aa96a72530badc0d0b378a3be">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Wilhelm Hense's <title render="italic">Die Sinnsprurche des Omar
+                  Khayyam Edward Fitzgerald's Englische Version Metrisch verduetscht.</title>
+                Cleveland Ohio, The German Consolidated Newspaper Co. 1924 (Lilly PK6514 .G4 H4
+                1924).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_bd01c7be7afc56bf7726b5e8f047c24a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0cb3d8164d6cceb72c8eacfc94d9708e" level="file">
+          <did>
+            <unittitle><persname>Goldman, Emma, 1869-1940, anarchist.</persname> London. Christmas
+              card to Roger Nash Baldwin?</unittitle>
+            <unitdate datechar="creation" normal="1924-12/1924-12" type="inclusive">1924 December
+              -</unitdate>
+            <physdesc id="aspace_a8d82eb4e1328046867eff2fa4204e77">Documtn signed 1 p. 12
+              cm.</physdesc>
+            <container id="aspace_6c132fb29ff807232d4a985e51ad1404" label="box" type="box"
+              >7</container>
+          </did>
+          <acqinfo id="aspace_e290cdfaa775cf4dd47f452af5e7d14f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Roger Nash Baldwin, New York, New York. <date normal="1951">1951.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b549f992ab3e7988168c8a425665233d" level="file">
+          <did>
+            <unittitle>Two manuscript translations from Tagalog to English.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">2 autograph
+                documents</extent></physdesc>
+            <unitdate datechar="creation" normal="1924/1924" type="inclusive">1924 -</unitdate>
+            <container id="aspace_d268a2101697c6e31fb0a190d79418a6" label="box" type="box"
+              >7</container>
+          </did>
+          <scopecontent id="aspace_1db55a1fa844f249a869d51c6da3acbe">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Titles are as follows: 1) The Life of A Merchant Proceso and His Daughter, Maria
+                in the Kindgom of Hungary (based on history carefully transposed into poetry on the
+                customary Filipino way of etertaining, by a young student); 2) Life of D. Alejandre
+                and D. Luis</item>
+              <item>Includes IUCAT printouts of Tagalog materials (seemingly the texts from which
+                these translations derive?)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_151e9bb2f45c69057162d710879f92ba">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Moira Smith, Main Library. <date normal="2001">2001.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9956cb59ba50c3445cc97bd26394b240" level="file">
+          <did>
+            <unittitle>Aubrey-Fletcher, Sir Henry Lancelot, bart., 1897-1969. London. To William
+              Gershom Collingwood. Asks to be put "on the track of books or people" to give him
+              information on his family history.</unittitle>
+            <unitdate datechar="creation" normal="1926-01-14/1926-01-14" type="inclusive">1926,
+              January 14 -</unitdate>
+            <physdesc id="aspace_17061dd2543b489294f7a3ab2b019bc4">Autograph letter signed 4 p. 17
+              cm.</physdesc>
+            <container id="aspace_be078605f8cde6b29bdb24b8b669d7ae" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_43273f3c0a8c4e081031063425a289ad">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from William Whellan, <title render="italic">History and topography of
+                  the counties of Cumberland and Westmoreland...</title> Pontefract, 1860 (Lilly
+                Wordsworth DA670 .C9 W56).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6db579a831dd4e68a75313ec2dbe5cea">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1952">1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bbeb76aae772dfccb5b144d42de63320" level="file">
+          <did>
+            <unittitle><persname>Sowers, Edwin Uhler, 2d., Berwyn Park, Lebanon, Pennsylvania,
+                printer.</persname> To Mr. Fuller, London County Council School of Printing and
+              Allied Trades, Stamford Street, London, England. Sending a gift volume in appreciation
+              for courtesies extended during a visit in July of 1926.</unittitle>
+            <unitdate datechar="creation" normal="1927-12-15/1927-12-15" type="inclusive">1927,
+              December 15 -</unitdate>
+            <physdesc id="aspace_cbf6733e5d59c850b0ae8a707be3d0de">Typescript letter signed 1 p.
+              26.5 cm.</physdesc>
+            <container id="aspace_401b523f680d9d70403d6b89d202abe7" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_934b917ff13dadeb883e2de6528a5c32">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by carbon on pink paper of Mr. Fuller's reply, typescript letter 1
+                p. 25.5 cm., dated 1927, Dec. 31</item>
+              <item>Removed from <title render="italic">Preface to the Nigger of the
+                  Narcissus,</title> by Joseph Conrad. Lebanon, Pa., E. U. Sowers II, 1927 (Lilly
+                PR6005 .O4 N59 1927).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cfa863b7e0ef343e299dcac087b36f86">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_aaba7619f39bcd1343672ce27a5508ca" level="file">
+          <did>
+            <unittitle>Hallock, Rev. H. G. C. To "Friend." "Enclosed I send you a tiger." Discussed
+              mythology surrounding the figure of the tiger.</unittitle>
+            <unitdate datechar="creation" normal="1927-04-28/1927-04-28" type="inclusive">1927,
+              April 28 -</unitdate>
+            <physdesc id="aspace_5d982fa4bcf3510ec9382f6edf8af67f">Typescript letter signed 1
+              p.</physdesc>
+            <container id="aspace_3067303bf3c312cc76e0381baaaa4fae" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_d397c05f568e8da2dddcea2d9be50ce9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by fold-out illustration of a tiger</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8ea69853238fa7ccad9b3f9f17902b20">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6aa78549d93ce4a09f9fde86dd2f1f11" level="file">
+          <did>
+            <unittitle>Letter from Director and Registrar of the Institute of Women Secretaries,
+              Ltd., to Miss Jr. R. Macalister.</unittitle>
+            <unitdate datechar="creation" normal="1927-12-15/1927-12-15" type="inclusive">1927,
+              December 15 -</unitdate>
+            <physdesc id="aspace_d92730c711c17220108294e3750042b0">Typescript letter signed 1
+              p.</physdesc>
+            <container id="aspace_74bb36b5f45bba11efe13f958c1b6a66" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_87cb1eb9f9b5c525ce4bdfc8ccf11076">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">The Personal secretary...</title> London:
+                Institute of Women Secretaries (1927?) (Lilly HF5547.5 .I59)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a820ef775de9d224d6f3a09f761bd742">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1995">1995.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_74261b778fd5a64b379de89e7fa3c60a" level="file">
+          <did>
+            <unittitle>Gruel, Leon. To Peter, M. Bill for binding Dante's <title render="italic"
+                >Vita Nova.</title></unittitle>
+            <unitdate datechar="creation" normal="1927/1927" type="inclusive">1927 -</unitdate>
+            <physdesc id="aspace_f687952f81d61e8bb81fdd8b4f98bcca">Document signed 1 p.</physdesc>
+            <container id="aspace_8128de2f5fd320a2f325f3398e1c6d94" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_bb0190fb0071268732cec44ad04b83bd">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes sample sketch of binding</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a02f88a1d0826b1fd54b3b90dabe0493">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4f808010c7bd2a32bd5a7e679843f5a3" level="file">
+          <did>
+            <unittitle><persname>Minnigerode, Meade, 1887-1967, author.</persname> Yale Club, New
+              York, N.Y. To Mrs. Robert Elisha Burke, Bloomington, Ind. Thanking her for a Jenny
+              Lind clipping.</unittitle>
+            <unitdate datechar="creation" normal="1928-05-24/1928-05-24" type="inclusive">1928, May
+              24 -</unitdate>
+            <physdesc id="aspace_7bd7b25dec085a107d787fac75e18e7d">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_9b39ea4cad226ee474fdfb17843286ae" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_6e27b363b9053f0ce5a0dd61b4bf2d40">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Robert E. Burke, Bloomington, Indiana. <date normal="1952"
+              >1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_a840e6fbf8e3c9fe51263c53176e1d96" level="file">
+          <did>
+            <unittitle>Hallock, H. G. C. to Alexander, W. A.</unittitle>
+            <unitdate datechar="creation" normal="1928-11-20/1928-11-20">1928, November
+              20</unitdate>
+            <container id="aspace_63b06934f5788b73889bfb386a89bcd3" label="mixed materials"
+              type="Box">15</container>
+          </did>
+        </c02>
+        <c02 id="aspace_5fa09e67498c83773819a0990934b0a4" level="file">
+          <did>
+            <unittitle><persname>Kessler, Ramon Wilke, 1905-?, author.</persname> Flight formation:
+              a collection of best airplane stories for boys and girls.</unittitle>
+            <unitdate datechar="creation" normal="1930-03-27/1930-03-27" type="inclusive">1930,
+              March 27 -</unitdate>
+            <physdesc id="aspace_e01761ec35a6f446ae4f6df0e2908510">Document signed 12, 210 p. 28
+              cm.</physdesc>
+            <container id="aspace_fee654023af77e7571580d666a040fb5" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_44eecf6b0bef507bbfc2e71595da6eb2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Published as: <title render="italic">The right to solo: a collection of the best
+                  airplane stories for boys and girls...</title> New York, Dutton, 1931.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8b9768863b06a0dfcf158c39ee85bd66">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Ramon Wilke Kessler. <date normal="1931">1931.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7478c018ee7c1f5366d0c38921dff9e4" level="file">
+          <did>
+            <unittitle><persname>Marshall, Sir John Hubert, 1876-1958, director general of
+                archaeology in India.</persname> Taxila, India and Guilford, England. To Arthur
+              Bernard Cook, Queen's college, Cambridge. Concerns Cook's reading of proof of Sir John
+              Hubert Marshall's <title render="italic">Mohenjo-Daro and the Indus
+                Civilization</title> and congratulating him on his election to the British
+              academy.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">2 letters
+                signed; 1 autograph letter signed 4 p. 23-33 cm.</extent></physdesc>
+            <unitdate datechar="creation" normal="1930-12-24/1941-07-29" type="inclusive">1930,
+              December 24-1941, July 29 -</unitdate>
+            <container id="aspace_2c3f924e687a2c12e8af3df18363c12c" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_17cd8dd177f374c335775ed6ee06618b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Sir John Hubert Marshall's <title render="italic">Mohenjo-Daro and
+                  the Indus Civilization...</title> London, Arthur Probsthain, 1931, 3 vols (DS486
+                .M6 M36).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d34ca01ce263e2c0cf53da8897a4a022">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1953">1953.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a2b046b39bf94fcbac93cb44fc1f0815" level="file">
+          <did>
+            <unittitle>Schueler, Edward. The Bedford-Nugent Company Inc. River Front, Foot of
+              Goodsell Street, Evansville, IN. To Al Jolson. 1041 N. Formosa, Hollywood, CA. "I am
+              anxious to know if you were a party in this act here [at the Bijou of Evansville, IN]
+              over twnty [sic] years ago."</unittitle>
+            <unitdate datechar="creation" normal="1931-04-25/1931-04-25" type="inclusive">1931,
+              April 25 -</unitdate>
+            <physdesc id="aspace_9bf8e62e95793322a418ca17df5a7e62">Typescript letter signed 1 p. 28
+              cm.</physdesc>
+            <container id="aspace_d3249139ee59261390b8eb6e1ba79c48" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_53616c9b7a1de5baffa73c42c28b2111">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Holograph reply initialed JMS, Mgr. "Yes, Mr. Jolson was in the act."</item>
+              <item>Removed from Theater Programs, Evansville, Indiana. Bijou Theater, March 18,
+                1906 (Lilly PN2220 .T372 No. 5)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c922a4cdb9df4674853120649f2d41fb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bddc5b9e98ea0acf401f5f61142019ad" level="file">
+          <did>
+            <unittitle><persname>Edmonds, Sir James Edward, 1861-1956, army officer.</persname> To
+              war office. Refers to military activities in August-September 1914.</unittitle>
+            <unitdate datechar="creation" normal="1932-07-01/1932-07-01" type="inclusive">1932, July
+              1 -</unitdate>
+            <physdesc id="aspace_f38f7a0cc6ab3c2a8e9d1cd231d6c9cd">Typescript document copy 1 p. 33
+              cm.</physdesc>
+            <container id="aspace_176954a0afcc129d81881c0e1dc2ac0c" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_e5d013ba22de785dab59fcef47953d2e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from E. L. Spears, Liaison, 1914: <title render="italic">A Narrative of
+                  the Great Retreat.</title> London, William Heinemann, 1930 (Lilly D544 .S7
+                1930).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0b1167d4fee7d55483367da83d884786">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1965">1965.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_272d92d7ec50ed6d9640ab83692b84e3" level="file">
+          <did>
+            <unittitle>Wendell, Edith (Greenough), 1859-1938. 358 Marlborough Street, Boston,
+              Massachusetts. To ? Concerns books sent to her husband Barrett Wendell by Henry
+              Adams.</unittitle>
+            <unitdate datechar="creation" normal="1933-05-01/1933-05-01" type="inclusive">1933, May
+              1 -</unitdate>
+            <physdesc id="aspace_b6d088536d4a58caa9ef642f3e60f0f7">Autograph letter 2 p. 17
+              cm.</physdesc>
+            <container id="aspace_0cf1d5c9aa5d9e0b1d0f440e5e73f8df" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_18d9d805ba0e5130e8a7dd20bebf6aad">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">The education of Henry Adams.</title>
+                Washington, 1907 (Lilly E175.5 .A17).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_60f0cca9cbf90733125233c805253332">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_94731cf65d589fe070c1e2a67b669c27" level="file">
+          <did>
+            <unittitle><persname>Lloyd, John Uri, 1849-1936, pharmacist.</persname> New Year's
+              card.</unittitle>
+            <unitdate datechar="creation" normal="1933/1933" type="inclusive">1933 -</unitdate>
+            <physdesc id="aspace_96795da05d41aad49c748c8cc4cf90e8">Document signed 7 cm.</physdesc>
+            <container id="aspace_1c30c73b2bc7b53ed72c718828453966" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_dca688a739f81dcd7a946935094387c6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_fe94d2bdcc710a3235e029e9bb8358f7">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_424fd26f8fd96dcd23fb99cb636d89b5" level="file">
+          <did>
+            <unittitle><persname>Hull, Henry, 1890-?, actor.</persname> 73 Perry Street, New York.
+              To Francis L. De Vallant, Brooklyn, New York. "You unconsciously and most beautifully
+              phrased my own approach to the playing of j'Jeeter' and I can do no better than to
+              repeat it..."</unittitle>
+            <unitdate datechar="creation" normal="1934-02-09/1934-02-09" type="inclusive">1934,
+              February 9 -</unitdate>
+            <physdesc id="aspace_97dbcdd91e2bef46e48fd00723cc4f6e">Typescript letter signed 1 leaf
+              26 cm.</physdesc>
+            <container id="aspace_bae5acd7e389505cf2c42cbd011fa9fe" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_93939545caac83becb56d80845c57459">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_933afe7e3c1c18f4ea06e4907b2b8ed8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_21bd5dea5948ddc96bcd276c8a1245e6" level="file">
+          <did>
+            <unittitle>Rasmussen, A., fl. 1934, of Victor Gollancz Limited, 14 Henrietta Street,
+              Covent Garden, W.C.2. To Mr. Small. Enclosing a copy of the pamphlet <title
+                render="italic">Fascists at Olympia...</title> "[which] will be read not only
+              Socialists and Left-Wingers, but by the many thousands of people of all shades of
+              politics...alarmed and disgusted at reports of the Olympia meeting..."</unittitle>
+            <unitdate datechar="creation" normal="1934-07-04/1934-07-04" type="inclusive">1934, July
+              4 -</unitdate>
+            <physdesc id="aspace_24ea49de4494f1f652566457bfaaa1b4">Typescript carbon signed 1 p. 25
+              cm.</physdesc>
+            <container id="aspace_075a81d28094bbd871e34fad2f8d3760" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_9ae1f157ff6bbd2481b347740d18c75a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Henry Thomas Hopkinson, <title render="italic">Fascists at
+                  Olympia...</title> London, Victor Gollancz Ltd., 1934 (Lilly DA578 .H798
+                F2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e985c9f00abadfd8c1094aa6b0d85275">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1974">1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_27472133976bef9a927fda5b19eac65e" level="file">
+          <did>
+            <unittitle><persname>Goldreyer, Michael, press representative.</persname> Forrest
+              Theatre, West 49th Street, New York. To Francis L. De Vallant, 420 Clinton Avenue,
+              Brooklyn, New York. "...it may be a good idea for you to write him your thoughts on
+              this matter--viz--stating your reason why Tobacco Road has impressed you to such an
+              extent that you had to see it twelve times..."</unittitle>
+            <unitdate datechar="creation" normal="1935-04-06/1935-04-06" type="inclusive">1935,
+              April 6 -</unitdate>
+            <physdesc id="aspace_aef5ed4e91d3f8ec860659a3ae8c3b98">Typescript letter signed 1 leaf
+              28 cm.</physdesc>
+            <container id="aspace_f2bf6832bf486dfd2cab39246c36994a" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_d9ea40cc1f87b1af1c1cc577c39bb239">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8203882053997cb9c8a6bb9a98d91687">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5baa3eac8a3d1ae4e2a524bb8fe99b89" level="file">
+          <did>
+            <unittitle><persname>De Vallant, Francis L., 1892/3-1958, advertising
+                executive.</persname> 420 Clinton Avenue, Brooklyn, New York. To Bernard Sobel,
+              Dramatic editor, Daily Mirror. "I note your comment in Saturday's MIRROR regarding my
+              having seen so many performance of "Tobacco Road," and that you are moved to wonder,
+              if not to actually chide me about my seeming lack of appreciation of other Broadway
+              productions."</unittitle>
+            <unitdate datechar="creation" normal="1935-04-08/1935-04-08" type="inclusive">1935,
+              April 8 -</unitdate>
+            <physdesc id="aspace_b09f91122f71ed6741bc76c183fb26cf">Typescript carbon 2 leaves 28
+              cm.</physdesc>
+            <container id="aspace_75cddd4ad7a94aaae271d28cc0d4716a" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_f514cdd1da9f5a1a62895a11851cd5a9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f13753641d2af5536c091af431fb4b0a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_319dbe5718a05d6a4a72930cf352a226" level="file">
+          <did>
+            <unittitle><persname>Johnson, Edith Christina, 1891-1954, educator.</persname>
+              Wakefield, England; London, England; and East Milton, Massachusetts. To James Bertrand
+              de Vinchelés Payen-Payne. Four personal letters and a postcard with references to her
+              research on Edward.</unittitle>
+            <unitdate datechar="creation" normal="1935-06-01/1936-08-17" type="inclusive">1935, June
+              1-1936, August 17 -</unitdate>
+            <physdesc id="aspace_05899a6bfd32072011998684d494f9a3">Autograph letter signed 17 p.
+              9-26 cm.</physdesc>
+            <container id="aspace_bbb06504586660e23ddbc0338e22ad9a" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_66d39dce6c54f42b012cce3839f95ce1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_264773822c51637b1939f5417cc73351" level="file">
+          <did>
+            <unittitle><persname>Tolstoi, Aleksei Nikolaevich, graf, 1882-1945, novelist,
+                dramatist.</persname> Presentation note.</unittitle>
+            <unitdate datechar="creation" normal="1935-09-08/1935-09-08" type="inclusive">1935,
+              September 8 -</unitdate>
+            <physdesc id="aspace_168599b65b9d6d28b94c6c9ed91a8d79">Autograph note signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_912ae6ab1dc9412863dad66998c620ba" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_58376b64ea5fbb75ac418ee258621b86">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Russian</item>
+              <item>Removed from Petr. Pervyi. Leningrad, 1935 (Lilly PG3476 .T6 P4).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3aef9b677eeedadcc39f8adbf30c8ff2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_450dfefc061b474df12b45b6bb7b2a0b" level="file">
+          <did>
+            <unittitle><persname>Carruthers, Alexander Douglas Mitchell, 1881-1962,
+                explorer.</persname> Barmer Hall, King's Lynn. To Messrs. J. A. Sinclair. 3
+              Whitehall, S.W. 1. Deals with a display to advertise <title render="italic">Arabian
+                adventure.</title></unittitle>
+            <unitdate datechar="creation" normal="1935-10-06/1935-10-06" type="inclusive">1935,
+              October 6 -</unitdate>
+            <physdesc id="aspace_2093eb10489c56cea8d768f6c7e2f050">Autograph letter signed 3 p. 18
+              cm.</physdesc>
+            <container id="aspace_d3b4e0ab4a2d82ebd4e575b6776b149a" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_d592ab101bc3847add06ad728c70a15b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Carruthers, <title render="italic">Arabian adventure...</title>
+                London, H. F. &amp; G. Witherby, 1935 (Lilly DS207 .C18).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b3752ee746d2efacd45bf09f57f205fd">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1966">1966.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a70dc87569790bf5bd361cc81f92e8fb" level="file">
+          <did>
+            <unittitle><persname>Hunter, Ruth, actress.</persname> To Francis L. De Vallant. "It was
+              so nice of you to wire me on the thousandth performance."</unittitle>
+            <unitdate datechar="creation" normal="1936-03/1936-03" type="inclusive">1936, March
+              -</unitdate>
+            <physdesc id="aspace_ff5e617f6a531ce76e08d1340fa28497">Autograph letter signed 1 leaf 18
+              cm.</physdesc>
+            <container id="aspace_67202553555ecb917db460e00e9d24cf" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_36b7ae17d1b3ac21dcdf63488fc9044d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In lower left hand corner: "Tobacco Road - Monday, 10:30"</item>
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_df4b1a2ee137c222f9960c388ca402a3">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_234615343a64c1ebf1342c1dfe62d90f" level="file">
+          <did>
+            <unittitle><persname>Adams, Franklin Baldwin, 1910-?, librarian.</persname> New York,
+              N.Y. To Carroll Atwood Wilson, New York, N.Y. First edition of English translation of
+              Karl Marx's <title render="italic">Das Kapital</title>; Russian and French
+              translations of <title render="italic">Das Kapital</title>; Samuel Moore's corrections
+              of first English edition of <title render="italic">Das Kapital.</title></unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">2 typescript
+                letters signed 5 p. 26 cm.</extent></physdesc>
+            <unitdate datechar="creation" normal="1936-07-28/1936-08-06" type="inclusive">1936, July
+              28-August 6 -</unitdate>
+            <container id="aspace_4735b51f3bcb6577c3c7b678a6ec1fb9" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_deba2094a44c7524cda5c379f8a608b1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by typed list of Moore's corrections</item>
+              <item>Removed from Karl Marx, <title render="italic">Capital...</title> New York, The
+                Humboldt Publishing Co., 1890 (Lilly HB501 .M308).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d0675590a0096bd9ebcfafc83bf4b47b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0f0d1cffdf178834338279471fce8ed1" level="file">
+          <did>
+            <unittitle><persname>Petrie, Sir William Matthew Flinders, 1853-1942,
+                egyptologist.</persname> American School of Research, Jerusalem. To Dear Sir. "There
+              is work to be done for centuries to come in the interminable tells or town mounds, the
+              difficulty is politics and costs."</unittitle>
+            <unitdate datechar="creation" normal="1937-04-21/1937-04-21" type="inclusive">1937,
+              April 21 -</unitdate>
+            <physdesc id="aspace_920450e484151bc649560a86affd1c04">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_9671f26a1c71d6052c1e01f521b3d88c" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_15e0fb7312648b750289c2083c4717dc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Letterhead of British School of Egyptian Archaeology</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cb481366b77a6b371659b969d751ebdb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Goodspeed's Book Shop, Inc., 18 Beacon Street, Boston, Massachusetts.
+                <date normal="1973">1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_01f9367a65076067ca455e4bbb6df215" level="file">
+          <did>
+            <unittitle>McCoy, Florence Littlefield, Grasse, A.M., France. To Mr. Ford. Sending him a
+              copy of her husband's <title render="italic">Jesuit Relations of
+              Canada.</title></unittitle>
+            <unitdate datechar="creation" normal="1937-05-15/1937-05-15" type="inclusive">1937, May
+              15 -</unitdate>
+            <physdesc id="aspace_7700eee1103fcf0d47eeb04442b1cb44">Autograph letter signed 3 p. 10
+              cm.</physdesc>
+            <container id="aspace_fa11418c1912a8b53580a2d0c46e7037" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_0eece0ec331fc7434c858a0b04a15213">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on front fly-leaf of James Comly McCoy's <title render="italic">Jesuit
+                  Relations of Canada, 1632-1673: a Bibliography...</title> Paris, Arthur Rau, 1937
+                (Lilly Z7840 .J5 M2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c5ceb99b5e7136529ef6521002d9d5c8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1ed326aec9ea808af92ad0b7fa394867" level="file">
+          <did>
+            <unittitle>McCoy, Florence Littlefield, Grasse, A.M., France. To Mr. Ford. Appreciates
+              his comments on her husband's book; enclosing a bookplate.</unittitle>
+            <unitdate datechar="creation" normal="1937-12-12/1937-12-12" type="inclusive">1937,
+              December 12 -</unitdate>
+            <physdesc id="aspace_8610b3de3c8d0ef4023587530edc83e4">Autograph letter signed 3 p. 10
+              cm.</physdesc>
+            <container id="aspace_81cafb0ae4c3aa38bd53d0ac53f30592" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_b525f1e914a9e62e4c188a9f2240152c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on front fly-leaf of James Comly McCoy's <title render="italic">Jesuit
+                  Relations of Canada, 1632-1673: a Bibliography...</title> Paris, Arthur Rau,
+                1937.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3149ba328cfde7613ca68d9a9600ec2f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_68975a29dae38ba13d464aa5d90fd8df" level="file">
+          <did>
+            <unittitle>Photograph of Orson Welles and Martin Gabel in the play Julius
+              Caesar.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">28 x 35.5
+                cm.</extent></physdesc>
+            <unitdate datechar="creation" normal="1937/1937" type="inclusive">1937? -</unitdate>
+            <container id="aspace_03fbb61e4a193eb8b994ae4ebe27729a" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_1d6feda749b62c880ea0850a2e20c353">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Black and white photograph</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_661680d3d6332cb1688c8d977ef496df">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. William B. Perrin. Bloomington, Indiana. <date normal="1989">1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_91c7de6cf94cec4b2a2d1138c5170d55" level="file">
+          <did>
+            <unittitle><persname>Doysié, Abel, 1886-?, author.</persname> Fairfield, Connecticut. To
+              Frank D. Lowe, Watertown, New York. Lecture tour.</unittitle>
+            <unitdate datechar="creation" normal="1938-06-09/1938-06-09" type="inclusive">1938, June
+              9 -</unitdate>
+            <physdesc id="aspace_04912678272a245ae17a962f5c2df0a3">Autograph letter signed 2 p. 17
+              cm.</physdesc>
+            <container id="aspace_6f9df7bda1ac41504dbc905354c1dd78" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_92ff259dfc11f76619b158bc0808c9e1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bb47c4741b6c6330401975d6a4d7d10d" level="file">
+          <did>
+            <unittitle><persname>Randall, David Anton, 1905-1975, bookman.</persname> New York, N.Y.
+              To Harry T. Peters, New York, N.Y. Duplicate volumes of <title render="italic"
+                >American Turf Register.</title></unittitle>
+            <unitdate datechar="creation" normal="1939-01-06/1939-01-06" type="inclusive">1939,
+              January 6 -</unitdate>
+            <physdesc id="aspace_a5c865c5feafe575797230524dec369b">Typescript letter signed 1 p. 27
+              cm.</physdesc>
+            <container id="aspace_1a5afbff1a4cc68088797305007893cc" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_690ff384efbe87aa8152103282dbd3de">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by carte de visite and memorial card of Anna Sewell</item>
+              <item>Removed from Anna Sewell, <title render="italic">Black Beauty...</title> London,
+                Jarrold and Sons, n.d. (Lilly PR5349 .S47 B58).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_269fc6d1cac9d521a796fd4b0c6043d9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7f6ea394097817c558aee56bcced9d20" level="file">
+          <did>
+            <unittitle>Berry Bros. &amp; Co., 3, St. James's Street, London. Sales letter regarding
+              wine from the vineyard of CH. L'ARCHEVESQUE at St. Emilion, France.</unittitle>
+            <unitdate datechar="creation" normal="1939-02-08/1939-02-08" type="inclusive">1939,
+              February 8 -</unitdate>
+            <physdesc id="aspace_ba746e15ff23cc1709ad12d8a888cddb">Mimeo copy 1 p. 25.5
+              cm.</physdesc>
+            <container id="aspace_08892a85fd399e5310069e42f5c15225" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_9bf5c9125dc2e2328573cc6da39a890a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Date typed on letter</item>
+              <item>Accompanied by four printed wine labels from other vineyards in France</item>
+              <item>Transferred from Lilly PN6237 .S25</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d781f781b100a05c90a192cb211861e2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1979">1979.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_b7896a328090a93d99455efb5d02390c" level="file">
+          <did>
+            <unittitle>Foster, John G. Letter to Julia Hart Lyon.</unittitle>
+            <unitdate datechar="creation" normal="1939-07-01/1939-07-01" type="inclusive">1939, July
+              1 -</unitdate>
+            <physdesc id="aspace_9dfdf10adbe28ab25c4aa7ae04e79cbe">Autograph letter signed 3
+              p.</physdesc>
+            <container id="aspace_361043da36fa2241fd5a9dbda073fe9d" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_e0d011360180a21e091d922a4d85cd0f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Lyon, <title render="italic">Women Must Love.</title> Faber &amp;
+                Faber, London, 1937 (Lilly PR6023 .Y5 W81).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8ae53de126239e79ae2698613b358bae">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_76b8e52ca6d360ddb920df9a112e84fc" level="file">
+          <did>
+            <unittitle>Steggall, Margaret, London, England. To Mr. and Mrs. Robert Elisha Burke,
+              Bloomington, Indiana. Description of London in wartime.</unittitle>
+            <unitdate datechar="creation" normal="1940-01-24/1940-01-24" type="inclusive">1940,
+              January 24 -</unitdate>
+            <physdesc id="aspace_234dd8fca615c751c18f2bdca8e6ec43">Autograph letter signed 4 p. 25
+              cm.</physdesc>
+            <container id="aspace_2755e064f38c622738b3cefe501ad5a5" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_c28c5c9b4e6b991b92e5c433dc29e08f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Robert E. Burke, Bloomington, Indiana. <date normal="1954"
+              >1954.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_008aeb8b31f07724ce77c7c793d4ce4f" level="file">
+          <did>
+            <unittitle><persname>Goldreyer, Michael, press representative.</persname> To Francis
+              H[sic] De Vallant, 420 Clinton Avenue, Brooklyn, New York. "In my release...I
+              specifically stated that you were in complete charge of the advertising and publicity
+              department of Fairchild's..."</unittitle>
+            <unitdate datechar="creation" normal="1940-03-04/1940-03-04" type="inclusive">1940,
+              March 4 -</unitdate>
+            <physdesc id="aspace_2e7359af0cc83e87cf0ea98094994527">Typescript letter signed 1 leaf
+              23 cm.</physdesc>
+            <container id="aspace_c5933532e89306e2121d804a5f0e70b0" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_c70d35f3d2f1ddbf345404d8d66c486f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Letter head of Jack Kirkland presents "Tobacco Road" from Michael
+                Goldreyer</item>
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_afed2f6337512210d850aca961d48ea7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f6a6a04c11a722d4105575d0c247133f" level="file">
+          <did>
+            <unittitle><persname>Laski, Harold Joseph, 1893-1950, author, educator.</persname>Devon
+              Lodge, Addison Bridge Place, W14. To Dean Bernard Campbell, Gavit, The Law School, The
+              University of Indiana, Bloomington, Indiana, U.S.A. Refers to an essay by Sir Henry
+              Maine on Thomas Hobbes which was enclosed.</unittitle>
+            <unitdate datechar="creation" normal="1946-05-06/1946-05-06" type="inclusive">1946, May
+              6 -</unitdate>
+            <physdesc id="aspace_688f7e3b363dc9a5c0b19659218160e0">Autograph letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_f89b6f432bba8978ec46ba42a9d7583c" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_085d5ce8dae70f9e05c01c7990d8b3d4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Law School Library, Indiana University, Bloomington, Indiana, by
+              Betty LeBus, librarian. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_bb9638d36c69f7b31090ac6c4bdae5bb" level="file">
+          <did>
+            <unittitle><persname>Maggs, H. Clifford, 1905-1985, book dealer.</persname> 50 Berkeley
+              Square, London, W. 1. To Bernardo Mendel. Apartado Nacional: 18-70, Bogota, Colombia,
+              S. A. "We are glad to give you particulars of the MAGICA DE SPECTRIS."</unittitle>
+            <unitdate datechar="creation" normal="1946-08-19/1946-08-19" type="inclusive">1946,
+              August 19 -</unitdate>
+            <physdesc id="aspace_221d2c821f544bee04d6f88e910c2964">Typescript letter signed 1 p. 25
+              cm.</physdesc>
+            <container id="aspace_5e1870c6d0027b47bfd8456924893fee" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_9784eb6800efffd4d2fbc3396d23e990">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On Maggs Bros. stationery</item>
+              <item>Has bibliographical information about <title render="italic">Magica de spectris
+                  et apparitionibus spiritu de vaticiniis divinationibus &amp;c.</title> Lugd.
+                Batavorvm: Apud Franciscum Hackium, 1656 (Lilly BF1520 .M194 1656).</item>
+              <item>Includes epitaph for Maggs</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_38e72d5126a95ffe93c92389ff978eeb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transfer. Lilly Library Book Department Bibliographic File, Indiana University,
+              Bloomington, IN. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5abb550c82478e9688bdbd8845f96d77" level="file">
+          <did>
+            <unittitle><persname>Blanck, Jacob Nathaniel, 1906-?, bibliographer.</persname> New
+              York, New York. To Carroll Atwood Wilson, 161 West 16th Street, New York, New York.
+              Bibliographical informration with a note that "Lib'n Luther Evans of the LC withdraws
+              from its agreement to provide copyright dates."</unittitle>
+            <unitdate datechar="creation" normal="1946-09-10/1946-09-10" type="inclusive">1946,
+              September 10 -</unitdate>
+            <physdesc id="aspace_a7b5601ae74072563726dd9cd07798bc">Typescript card signed 1 p. 8
+              cm.</physdesc>
+            <container id="aspace_4b8f11ecba5aafbfac53b572e9c4b0df" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_cd44edc96975a99aecf057cab42cf7b1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>One sentence and signature in pencil</item>
+              <item>Removed from Mrs. E. A. (Chase) Allen, <title render="italic">Poems...</title>
+                Boston, Ticknor and Fields, 1866 (Lilly PS1029 .A7 1866).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1846051c12b50fa45c289ca5b6c05040">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_891243ace274988cc0495d9c2f22827c" level="file">
+          <did>
+            <unittitle><persname>Churchill, Sir Winston Leonard Spencer, 1874-1965, prime
+                minister.</persname> Speeech delivered at Westminster College, Fulton,
+              Missouri.</unittitle>
+            <unitdate datechar="creation" normal="1946/1946" type="inclusive">1946 -</unitdate>
+            <physdesc id="aspace_29a875c71c569272fd5ffb7dda476ed0">Xerox copy</physdesc>
+            <container id="aspace_c283bc56e7e92d6e42c04571744327cc" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_4a370ccbcc0fb3ea010407de1ffcdd2b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Original is at Westminster College, Fulton, Missouri</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8f18d98815411ee3023bd72b355db3f7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1971">1971.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_658870d382e4c0045b461a52a9f2d262" level="file">
+          <did>
+            <unittitle>Hopkinson, Cecil, Petersfield, Hants, England. To Carroll Atwood Wilson, New
+              York, N.Y. Concerns the first publication of Handel's <title render="italic"
+                >Joshua.</title></unittitle>
+            <unitdate datechar="creation" normal="1947-01-11/1947-01-11" type="inclusive">1947,
+              January 11 -</unitdate>
+            <physdesc id="aspace_586c8a5934fd0d5ce4c0c3508f0f06f8">Typescript note signed 1 p. 9
+              cm.</physdesc>
+            <container id="aspace_495a0f25f10e02724cecfaca559c30ec" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_7822bf621c58983ffaaf9d8c22c321d2">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Postcard</item>
+              <item>Removed from George Friedrich Handel's <title render="italic">Joshua...</title>
+                London, Tonson and Draper, 1748 (Lilly ML50 .H2 J8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f6f7897382ea6fec3715f601136c8efe">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_145a6d2d63cd88c264ffa7169ac1003f" level="file">
+          <did>
+            <unittitle><persname>Harrison, E. M., missionary.</persname> Methodist Girls' School,
+              Wilberforce, Freetown, Sierra Leone. To Rev. and Mrs. William Sidney Handley Jones, 18
+              Dorville Road, Lee, London, S. E. 12, England. Miss Harrison teaches music and
+              comments on the relationship of the American, Church of England, and Methodist
+              missionaries.</unittitle>
+            <unitdate datechar="creation" normal="1947-08-31/1947-08-31" type="inclusive">1947,
+              August 31 -</unitdate>
+            <physdesc id="aspace_c6a324c0a7ef605a9f2f16a0459e3115">Autograph letter signed 3 p. 20
+              cm.</physdesc>
+            <container id="aspace_37bcb2d8746a2b749782af23d730681f" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_538d70fb26276fdb5dff7a5d33bbe650">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Aldous Leonard Huxley's <title render="italic">Verses and a
+                  Comedy.</title> London, Chatto &amp; Windus, 1946 (Lilly PR6015 .U9 V56).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8059b3f41027a3da97e2c9c52a494f2d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_546471a533ceb1ef1defe3822411623d" level="file">
+          <did>
+            <unittitle><persname>Evans, Willa McClung, 1899-?, professor.</persname> 134
+              Pennsylvania Avenue, Chambersburg, Pennsylvania. To Professor William Riley Parker,
+              Modern Language Association, 100 Washington Square East, New York City, 3. She writes
+              concerning a correction for the birthdate of Henry Lawes, musician.</unittitle>
+            <unitdate datechar="creation" normal="1947-09-17/1947-09-17" type="inclusive">1947,
+              September 17 -</unitdate>
+            <physdesc id="aspace_c600edcaf5219a994be3b6c86cf06fa2">Typescript letter signed 3 leaves
+              28 cm.</physdesc>
+            <container id="aspace_f3a473fb892ca8ae104279324ed10dbb" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_79cc6379f7c7fada0e9f7cf77b453c26">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Holograph additions in blue ink</item>
+              <item>Removed from Evans, <title render="italic">Henry Lawes, musician and friend of
+                  poets,</title> New York, Modern Language Association, 1941 (ML410 .L4 E9).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ed633b75a8c31b15fe274ed6ce0e7e49">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a9b97c1385a939abef06e95293ab7e29" level="file">
+          <did>
+            <unittitle>Cecil, Lady Eleanor (Lambton) Cecil, viscountess, ?-1959. Chelwood Gate,
+              Haywards Heath, England. To "Dorothy." Deals with Attlee as prime
+              minister.</unittitle>
+            <unitdate datechar="creation" normal="1947-12/1947-12" type="inclusive">1947, December
+              -</unitdate>
+            <physdesc id="aspace_819dfbe002902e63c9ca21f8d19a4ace">Autograph letter signed 4 p. 18
+              cm.</physdesc>
+            <container id="aspace_862757819c00001a0334bf7411fd607f" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_53920e49ea9eaf56b617499045f75d0f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_53929b97d94d45273b7322f171cdc5c8" level="file">
+          <did>
+            <unittitle><persname>Martin, Renwick Harper, 1872-1958, clergyman, organization
+                executive.</persname> To the Members of the Oath Committee of the Reformed
+              Presbyterian Synod. "The enclosed is submitted to you for your study and I trust your
+              approval."</unittitle>
+            <unitdate datechar="creation" normal="1949-05-13/1949-05-13" type="inclusive">1949, May
+              13 -</unitdate>
+            <physdesc id="aspace_a72e74955009311487c0b403fe40b036">Typescript letter signed 1 p. 35
+              cm.</physdesc>
+            <container id="aspace_c41d928116b3f38e4cefe86328c25c9c" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_88735b4cd0f63710b66d4f6073743018">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by envelope addressed to Henry Lester Smith, 705 E. Seventh Street,
+                Bloomington, Indiana</item>
+              <item>Enclosure: Can the oath to the Constitution of the United States required of
+                public officials, of those who would become citizens of our nation, of commissioned
+                officers in the armed services of our country and in other situations, be taken with
+                the oath-taker maintaining a supreme allegiance to God or Jesus Christ and giving
+                only a subordinate allegiance to the Constitution and nation? Typescript document 13
+                p. 35 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b72ec2076478c6745afc28b1a22b4404">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Education Department, Indiana University, Bloomington, Indiana. <date
+                normal="1977">1977.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e37f0f45bce1abf4c75e37ff4d8513ec" level="file">
+          <did>
+            <unittitle>Heiney, Ean Boyd, 1868-1950. To Mr. Riker. Birthday greetings.</unittitle>
+            <unitdate datechar="creation" normal="1950-02-16/1950-02-16" type="inclusive">1950,
+              February 16 -</unitdate>
+            <physdesc id="aspace_f9a13b103a3a8c04b6932c5c21756df4">Typescript letter signed 1 p. 18
+              cm.</physdesc>
+            <container id="aspace_5e8f1d0c868256aca8b479f1f027fd19" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_21f48278d01e1595784ac6cb7dbe74c1">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>On verso of Heiney's <title render="italic">February 26- Birthday
+                  Greetings.</title> McLean, Va., 1950.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d9a3402ffa654a5d17eece1e1aaf40b3">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_66be900caa9fa7cd6484a9130811db96" level="file">
+          <did>
+            <unittitle><persname>Muir, Percival Horace, 1894-1979, bibliographer.</persname> To
+              Montgomery Evans. Difficulty of collecting Evans's bills to him.</unittitle>
+            <unitdate datechar="creation" normal="1951-03-16/1951-03-16" type="inclusive">1951,
+              March 16 -</unitdate>
+            <physdesc id="aspace_a365199cd79f26af4018ec82ac68fa7d">Typescript letter signed 1 p. 13
+              cm.</physdesc>
+            <container id="aspace_35a057ad824350c150ca1d88d4ec8175" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_41ba0cb0050ece51008fb9fbb97c3ddf">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on back fly-leaf of Muir's <title render="italic">Points, second series,
+                  1866-1934...</title> London, Constable, 1934 (Lilly Z992 .M9 copy 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_eafa9b94521907734a50e230dc1bc0b0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_77449a4d38cc2fc8a54a34365717a1c3" level="file">
+          <did>
+            <unittitle>Clarke, Derek A. Letter to H. P. Kraus.</unittitle>
+            <unitdate datechar="creation" normal="1952-07-01/1952-07-01" type="inclusive">1952, July
+              1 -</unitdate>
+            <physdesc id="aspace_2021a8ba8e7f21ef11cf61d0c53d2598">Autograph letter signed 1
+              p.</physdesc>
+            <container id="aspace_44080c4decb61d777c1fbd7e2ae9e3e5" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_9f5b9615b27f9756d394728ad01689b7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Francisco de Xerez, <title render="italic">Libro primo de la
+                  conqvista del Peru...</title> Milano...1535 (Lilly F3442 .X6 1636).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_f53ae2c1b4a8d47e74d73f4c4912befe">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ac7f11af936e83b160cebf37f80d34b6" level="file">
+          <did>
+            <unittitle><persname>Foster, George, scriptwriter, and Mort Green,
+                scriptwriter.</persname> Eight television and radio scripts.</unittitle>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">28.5
+                cm.</extent></physdesc>
+            <unitdate datechar="creation" normal="1952-08-18/1953-07-01" type="inclusive">1952,
+              August 18-1953, July 1 -</unitdate>
+            <container id="aspace_b37243395a9433ac912e16e8cfcb7764" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_09a3561f02e1d1df65ac5d3ee4b05784">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Grey cloth binding</item>
+              <item>Spine: Assorted Stuff George Foster</item>
+              <item>All scripts apparently written by George Foster and Mort Green</item>
+              <item>Contains corrections and production notes</item>
+              <item>Includes: 1) The Sergeant is a Doll. Pilot script [television script] Aug. 18,
+                1952. mimeo. 50 p. 2) The Jackie Miles Story. A TV series starring Jackie Miles,
+                written by Mort Green and George Foster [television script] Script #1. n.d. carbon.
+                72 p. 3) The Jackie Miles Story. A TV series starring Jackie Miles, written by Mort
+                Green and George Foster. Script #1, 6th copy [television script] n.d. carbon. 53 p.
+                4) United Community Campaigns Show. Recorded Aug. 26, 1952 [radio script] mimeo. 27
+                p. 5) All Star Revue - Tallulah. 2nd revision [television script] 87 p. Oct. 11,
+                1952. mimeo. Includes printed program. 6) All Star Revue - Tallulah [television
+                script]. Nov. 8, 1952. mimeo. Includes printed program. 73 p. 7) The All Star
+                Revue...Perry Como [television script] Feb. 14, 1953. mimeo. Includes printed
+                program. 101 p. 8) Arthur Godfrey and His Friends - Hal Le Roy [television script]
+                July 1, 1953. 26 p. mimeo.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ae777697722aafc4f4597a73b51e6321">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f5b7f9462e6df44e1c1ed3a51bc11015" level="file">
+          <did>
+            <unittitle>Barton, Kathryn (Mullins), (Mrs. James Edward Barton). To Francis L. De
+              Vallant, 165 E. Tremont Ave., New York City. Four personal letters concerning De
+              Vallant's interest in Barton's acting.</unittitle>
+            <unitdate datechar="creation" normal="1952/1957" type="inclusive">1952-1957 -</unitdate>
+            <physdesc id="aspace_382db855dead35c9f04e7f1a5b751ce8">Autograph letter signed 4 p. 9-25
+              cm.</physdesc>
+            <container id="aspace_d6ef14dc9d42f0d47803238d47372dea" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_ee0b9240f8e1736ec896e616af1497d9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed Kay &amp; Jim Barton</item>
+              <item>Letters dated June 11 (2), Oct. 30, 1952, and Apr. 7, 1957, with covers for the
+                first three</item>
+              <item>Filed in one folder which includes a Christmas greeting</item>
+              <item>Part of a drama collection of 20th century plays</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ee9352ac02b5b036e7f767d261f7f61d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased from Phoenix Book Shop, 18 Cornelia Street, New York, New York, 10014.
+                <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4f033e06ba8820d189f1a471b6b3e194" level="file">
+          <did>
+            <unittitle>Gordimer, Nadine, 1923- , author. 5 Rosel Court, St. George's Street,
+              Bellevue, JOHANNESBURG, SOUTH AFRICA. To Mr. Rappaport. Glad to know that he likes her
+              book and that he has gone to "the trouble of ordering FACE TO FACE all the way from
+              Johannesburg." Is enclosing a photograph...</unittitle>
+            <unitdate datechar="creation" normal="1953-08-03/1953-08-03" type="inclusive">1953,
+              August 3 -</unitdate>
+            <physdesc id="aspace_b817a42a66b9c4a078e2a1431660c739">Typescript letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_a66e0f711ffcd65fe126bdac99877dfe" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_7a5aa6453e8913237dcb4ddf410bb740">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Gray stationery imprinted with name</item>
+              <item>Photograph not present</item>
+              <item>Removed from Gordimer, <title render="italic">Face to Face.</title>
+                Johannesburg, South Africa, Silver Leaf Books, 1949 (Lilly PR9369.3 .G6 F13).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_807c1828bb9add56b54261b8c8c8df89">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_058584d88286b0f31b2fe4dd52d906cf" level="file">
+          <did>
+            <unittitle><persname>Abrahams, Sir Adolphe, 1883-1967, physician.</persname> 97 Harley
+              Street, W. 1., London, England. To "My dear Gordon." Personal letter inquiring about
+              the recipient's health.</unittitle>
+            <unitdate datechar="creation" normal="1955-04-26/1955-04-26" type="inclusive">1955,
+              April 26 -</unitdate>
+            <physdesc id="aspace_4ac6ec03396879e3b750f633954fda85">Autograph letter signed 1 p. 11
+              cm.</physdesc>
+            <container id="aspace_c492c5c428bf3add6c7bf27312d756fb" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_11a8b0b7c885d1c46bb2767386cfe71e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_76bf1929b105dd4a662094d7c6ece7d3" level="file">
+          <did>
+            <unittitle><persname>Cape, Jonathan, 1879-1960, publisher.</persname> Jonathan Cape
+              Limited, Thirty Bedford Square, London, W. C. 1, England. To Charles Ralph Boxer,
+              Ringshall End, Little Gaddesden, Berkhamsted, Herts, England. Refers to the manuscript
+              of Capitaes do Brasil by Elaine Sanceau.</unittitle>
+            <unitdate datechar="creation" normal="1956-06-28/1956-06-28" type="inclusive">1956, June
+              28 -</unitdate>
+            <physdesc id="aspace_5ccd7c5ddef6433ec9434a4393790ed7">Typescript letter signed 1 p. 25
+              cm.</physdesc>
+            <container id="aspace_dbd4c0ec2ea5a55c0d0c08cada8f194f" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_919d470ffa8d8f07f1300c96b57b9a0c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Two comments in ink by Boxer after the signature of Cape.</item>
+              <item>On verso of this letter is Boxer's reply to Cape, July 2, 1956. Autograph letter
+                signed</item>
+              <item>Removed from Elaine Sanceau, <title render="italic">Capitaes do Brazil,</title>
+                translated by Antonio Alvaro Doria. Porto Livraria Civilizaças, 1956 (F2524
+                .S195).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9ac1dfb9422509b0d424c7a8aa9d80a3">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cbc813d54c4ae7061d4492bdda662f7c" level="file">
+          <did>
+            <unittitle>May, Margaret T., (Mrs. Frederick A. May). To Charles Joseph Singer. Her
+              translation of Galen.</unittitle>
+            <unitdate datechar="creation" normal="1957-12-15/1957-12-15" type="inclusive">1957,
+              December 15 -</unitdate>
+            <physdesc id="aspace_5c49ba4b169c7c4acc37707d1d8048da">Autograph letter signed 2 p. 20
+              cm.</physdesc>
+            <container id="aspace_91ccf30a86369878fe8f3722cb9f5668" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_7a136cbd83cb957cf0225ee998e9e70b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_256337c440026a763a1c62b223ab11fe" level="file">
+          <did>
+            <unittitle><persname>Leao, Joaquim de Sousa, 1897-?, author.</persname> The Hague,
+              Embiaxada do Brazil. To Charles Ralph Boxer. Deals with publications and a silver
+              medal with the bust of Philip IV.</unittitle>
+            <unitdate datechar="creation" normal="1959-10-26/1959-10-26" type="inclusive">1959,
+              October 26 -</unitdate>
+            <physdesc id="aspace_c4a6fd743d31d98834ff16f2783900fa">Autograph letter signed 1 p. 27
+              cm.</physdesc>
+            <container id="aspace_d495c8664e6f0d3e3e87cdc58ddf2c3f" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_2c0cc988c253b5261b40acf66888f735">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">Morenos; notas historicos sobre o engenho no
+                  centenario do atual solar.</title> Rio de Janeiro, Colibris, 1959 (F2651 .M84
+                L4).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_22eab7c61686748f73ec993ebb5fc230">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_eb0cd7ede4dfb5b01b577ad83f96fac3" level="file">
+          <did>
+            <unittitle><persname>Grabow, Bart, promotion director.</persname> John Gooseflesh:
+              inventor.</unittitle>
+            <unitdate datechar="creation" normal="1960-11/1960-11" type="inclusive">1960, November
+              -</unitdate>
+            <physdesc id="aspace_c679c12144428115f68ec544a8485854">Typescript document 23 p. 28
+              cm.</physdesc>
+            <container id="aspace_8075416b155993af6493a6b20e9e6654" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_56b7dda800a0ccadc1382416ca5d9bb5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Paper delivered before the Indianapolis literary club</item>
+              <item>Accompanied by letter from Bart Grabow to David A. Randall, Nov. 22, 1960.
+                Typescript letter signed 1 p. 28 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9089b0cb8ee3b7144f7a8acba0edbf54">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Bart Grabow, Indianapolis, Indiana. <date normal="1960">1960.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d688f880e77e94df4dad8f53201bd49d" level="file">
+          <did>
+            <unittitle><persname>Smith, Ronald Gregor, 1913- , professor.</persname> University of
+              Glasgow, 12 The University, Glasgow, W. 2, Scotland. To Mrs. Worsley. An answer to a
+              request about a story which he informs his correspondent may be found in the Gospel of
+              Peter.</unittitle>
+            <unitdate datechar="creation" normal="1962-04-27/1962-04-27" type="inclusive">1962,
+              April 27 -</unitdate>
+            <physdesc id="aspace_4a891b6ac9ddf67733107ffc8f3dbaa0">Autograph letter signed 1 p. 25
+              cm.</physdesc>
+            <container id="aspace_caf37272669090bd4dd19d16aee68563" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_dcfa8d2b845856358bae189c8fe45017">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Jabez Elliott, 10 Middle Lane, Ringwood, Hants, England. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_356c52b65342edb49387664c92670156" level="file">
+          <did>
+            <unittitle><persname>Kronenberg, Maria Elizabeth, 181-?, bibliographer.</persname> The
+              Hague. To Frederick Richmond Goff, Library of Congress, Washington, D.C. "...the
+              Gerardus de Zutphania book of Indiana University is now identified as a printing of
+              Heinrich von Neuss in Cologne to be dated between 1505-1510..."</unittitle>
+            <unitdate datechar="creation" normal="1963-03-30/1963-03-30" type="inclusive">1963,
+              March 30 -</unitdate>
+            <physdesc id="aspace_09ab147f9c3c9d28fdba0c87d8a1765d">Xerox of autograph letter signed
+              1 p. 28 cm.</physdesc>
+            <container id="aspace_f95dd2a6972986e6f039c2a79730e4e1" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_5b0f18189ec99b0bf63a796c0d04df97">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Gerardus Zutphaniensis. <title render="italic">Manuale noue logice,</title>
+                Cologne, Heinrich von Neuss, between 1505 and 1510 (Lilly PA3891 .A3 G35).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2123ef27bdd817afe4e0d9c6e48f630d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1963">1963.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_2556b30d5482ba85ebd26396513e5927" level="file">
+          <did>
+            <unittitle><persname>Adams, Thomas Randolph, 1921- , librarian.</persname>j The John
+              Carter Brown Library, Brown University, Providence 12, Rhode Island. To Dr. Bernardo
+              Mendel, Lathrop C. Harper, Inc., 8 West 40th Street, New York, New York. Thanks Mendel
+              for the gift of the book <title render="italic">Pintura</title> and informs him of the
+              history of the translations of the work.</unittitle>
+            <unitdate datechar="creation" normal="1963-05-03/1963-05-03" type="inclusive">1963, May
+              3 -</unitdate>
+            <physdesc id="aspace_39037dda307d09f3b0ade9be5fdbfbce">Typescript letter signed 1 p.
+              25.5 cm.</physdesc>
+            <container id="aspace_7e814e445d365f02499bebb575eaa20d" label="box" type="box"
+              >8</container>
+          </did>
+          <acqinfo id="aspace_2116903745e1dff6b2c6609b368629ef">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Lilly Library Book Department, Indiana University, Bloomington, Ind.
+                <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_3599d0f28f444b22fe40641fd8b85dfc" level="file">
+          <did>
+            <unittitle><persname>Quirino, Carlos, librarian.</persname> Republic of the Philippines,
+              Office of the President, National Heroes Commission, Manila. To Charles Ralph Boxer,
+              King's College Strand, W.C.2 London, England. Refers to publication of the proceedings
+              of the International Congress on Rizal, held in Manila on December 1961.</unittitle>
+            <unitdate datechar="creation" normal="1963-06-07/1963-06-07" type="inclusive">1963, June
+              7 -</unitdate>
+            <physdesc id="aspace_89d9462c171cef58e4a645134aacad7b">Typescript document copy 1 p. 27
+              cm.</physdesc>
+            <container id="aspace_3b24277f2080115ebb1660cc99008a4d" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_e8c0b05a512d175a249ab2fd71fa8786">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Paul Proust de La Gironière's <title render="italic">20 years in
+                  the Philippines.</title> Manila, Filipiniana Book Guild, 1962 (DS658 .L185
+                1962).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_656b868975961a8b5865f633715d9ccf">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ae592dc21168fed136ce3ef59e2f3fcd" level="file">
+          <did>
+            <unittitle>Ihde, Aaron J. Letter to George W. Heise.</unittitle>
+            <unitdate datechar="creation" normal="1963-07-25/1963-07-25" type="inclusive">1963, July
+              25 -</unitdate>
+            <physdesc id="aspace_4f3f2cfee3cdb36f696f27ce0c775675">Typescript letter signed 1
+              p.</physdesc>
+            <container id="aspace_8356042183c3f4aa19f1eb3e9203d727" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_91428f0a7aa44ca2867cd0a9f9a006fe">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Ihde, <title render="italic">The Development of Modern
+                  Chemistry,</title> New York, Harper &amp; Row, 1964 (Lilly QD11 .I44).</item>
+              <item>Includes biographical clipping of Ihde</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_746f7fe06652493611d565b1d47480c6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1984">1984.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_35f622ffa99142a1fceef708363eff3e" level="file">
+          <did>
+            <unittitle>Sheetz, Merle C., Ann Arbor, Mich. George Cullom Davis and Evelyn Morgan von
+              Herrmann interview Merle C. Sheetz about Jane Addams. Wordsworth Room, Lilly Library,
+              Indiana University, Bloomington, Indiana.</unittitle>
+            <unitdate datechar="creation" normal="1966-03-01/1966-03-01" type="inclusive">1966,
+              March 1 -</unitdate>
+            <physdesc id="aspace_d192331fc20cb03f549b799970802988">Tape recording. 1 reel. 1 7/8
+              i.p.s.; 1 hr. 11 min.</physdesc>
+            <container id="aspace_a98d622f71bec601186c9d447423794f" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <acqinfo id="aspace_18f08af4244ac4e565d9af4e4329cdb9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_7f968a7bac9fc3527c7c9639e95cfe55" level="file">
+          <did>
+            <unittitle>Sheetz, Merle C., Ann Arbor, Mich. Lecture for S 303 History of American
+              social welfare, and for S 304 Modern social welfare organization, Ballantine Hall 221,
+              Indiana University, Bloomington, Indiana.</unittitle>
+            <unitdate datechar="creation" normal="1966-03-02/1966-03-02" type="inclusive">1966,
+              March 2 -</unitdate>
+            <physdesc id="aspace_c21cac108b22d36134d6921ac323dda7">Tape recording. 1 reel. 6 1/4
+              inches. 3 3/4 inches per second.</physdesc>
+            <container id="aspace_b35c758b453b02b2ac13c95f60f0cca7" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_83dfe419a86279fea86bf80247be50cc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Duration: 43 minutes</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_da5b3e7a04fac0b9745c601d424840b9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0ae0bc08cd436100462b91cdc73af741" level="file">
+          <did>
+            <unittitle>Dawson, Thomas Damon, 1896-?. To Terence William Casidy, Indiana University,
+              Bloomington, Ind. Refers to his book the <title render="italic">Lost secrets of master
+                masons.</title></unittitle>
+            <unitdate datechar="creation" normal="1967-03-14/1967-03-14" type="inclusive">1967,
+              March 14 -</unitdate>
+            <physdesc id="aspace_cf08e2417ec0277800208c5775e99871">Typescript letter signed 3 p. 28
+              cm.</physdesc>
+            <container id="aspace_9d548bb6cf6d9c9ddf12d01bab3d1d45" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_9de80fa2f4e53fd76d8eaf0db6f16a98">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Dawson, Thomas Damon. <title render="italic">Lost secrets of master
+                  masons.</title> Chrisney, Indiana. Privately printed (Lilly BF1275 .F7
+                D27).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3c9cf3312c52f3f08c103b8ecceff451">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Thomas Damon Dawson, P. O. Box 96, Chrisney, Indiana. <date normal="1967"
+                >1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e4c04ab7a286c675c8a9a5bcd1316664" level="file">
+          <did>
+            <unittitle>Kraus, H. P. To Librairie Paul Jammes.</unittitle>
+            <unitdate datechar="creation" normal="1968-03-04/1968-03-04" type="inclusive">1968,
+              March 4 -</unitdate>
+            <physdesc id="aspace_4845ece7e7ca489964aa36c798d63967">Typescript letter 1 p.</physdesc>
+            <container id="aspace_b5b9731fa357f3db3b582321558851df" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_d2b5eac57269196e0886cbb76060043d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">Le baucher bibliographique</title> (Lilly
+                Z1019 .L69 1967)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a7be7ecfdfa5bf54d3ca63b255dbf571">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Oak Knoll. <date normal="2004">2004.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e30a2b21f6f4322057a05235d2d1031c" level="file">
+          <did>
+            <unittitle><persname>Buchanan, Wallace Davis, 1909-?, radiologist.</persname> 107
+              Jefferson Medical Arts Building, 919 East Jefferson Boulevard, South Bend, Indiana
+              46622. To Librarian [i.e. David Anton Randall], Eli [sic] Lilly Library, Indiana
+              University, Bloomington, Indiana. Presents a copy of the history of radiology in the
+              United States and Canada to the library.</unittitle>
+            <unitdate datechar="creation" normal="1969-07-23/1969-07-23" type="inclusive">1969, July
+              23 -</unitdate>
+            <physdesc id="aspace_16c6d9dbe9c1dce34c70cef41d6a59e9">Typescript letter signed 1 p. 28
+              cm.</physdesc>
+            <container id="aspace_ad486b1f7e8641a324b70b94ae061eeb" label="box" type="box"
+              >8</container>
+          </did>
+          <scopecontent id="aspace_ef30a9b8eba9bee5bd874a94e7c893df">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Volume presented was the one from which the letter was removed</item>
+              <item>Removed from Ruth and Edward Brecher, <title render="italic">The rays...</title>
+                Baltimore, Williams and Wilkins, 1969 (Lilly RM849 .B82).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7e37d95efd88fb66ec6be11d12543668">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1979">1979.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_47be2dc8b0c5310c42d07c1f1c192fb4" level="file">
+          <did>
+            <unittitle><persname>Gillespie, William, bookdealer.</persname> To Edward Percy Rich.
+              Quotes the entire Dietrich Eckart inscription of October 25, 1922, which Frau Hess has
+              sent to him.</unittitle>
+            <unitdate datechar="creation" normal="1976-03-09/1976-03-09" type="inclusive">1976,
+              February 9 -</unitdate>
+            <physdesc id="aspace_5e0c3af618d888db863f2e602ce550e6">Typescript letter 1 p. 15.5
+              cm.</physdesc>
+            <container id="aspace_b8debacdd0ea253a46184cbf714f9ce5" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_9f57fea399c4586071e4d6e4f4595c7f">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Incomplete: letter torn in half</item>
+              <item>Addressed to: Ted</item>
+              <item>Accompanied by photocopy of Eckart inscription as it appears in a book</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_dfcd615f66befc81af33978660fd02c5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from collection of Eckart pamphlets in the Lilly Library. <date
+                normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ef5686447ad72aa8d43d0dc1ed635495" level="file">
+          <did>
+            <unittitle><persname>Anderson, Eric Albert, 1948- , professor.</persname> Traditions in
+              conflict: Filipino responses to Spanish colonialism, 1555-1665.</unittitle>
+            <unitdate datechar="creation" normal="1976-02/1976-02" type="inclusive">1976, February
+              -</unitdate>
+            <physdesc id="aspace_b4ce2600c1a151917c478e8354283158">Xerox of typescript document iii
+              +321 p. 28 cm.</physdesc>
+            <container id="aspace_772d7b22027d272f011d46721670f92b" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_d77cd932929104336b589e901d6c6afc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Ph.D. thesis, Department of Government and Public Administration, University of
+                Sydney</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b17a8fe09960773a8b7c8939b22b2449">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Eric Albert Anderson, Visiting professor, Political Science Department, Indiana
+              University. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_82bd6f5d9dc93e5f6c6c05e11a037438" level="file">
+          <did>
+            <unittitle>Nesbitt, Alexander. To John.</unittitle>
+            <unitdate datechar="creation" normal="1980-09-20/1980-09-20" type="inclusive">1980,
+              September 20 -</unitdate>
+            <physdesc id="aspace_94296fa6038c9e5de93af9541d31cd0a">Autograph letter signed 1
+              p.</physdesc>
+            <container id="aspace_e640be0eae709df6bee325bf5348fba7" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_5c2ce08db188d6b5738f18e5082a313d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by two black and white photographs of Edward Catich</item>
+              <item>Removed from <title render="italic">Father Edward M. Catich, 1906-1979: scholar,
+                  scribe, author, artist, teacher</title> (Lilly NK3631 .C36 F25).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4f99e9d3d726103a9ec07bf2cccfbe8b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="2004">2004.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4b79b5ef29c24ded8636a1371cd187d3" level="file">
+          <did>
+            <unittitle><persname>Bennett, Josiah Quincy, 1913-1991, bookman.</persname> Tallis's
+                <title render="italic">London Street Views</title> [1838-1840]. Third draft. Lilly
+              Library, Indiana University, Bloomington, Indiana.</unittitle>
+            <unitdate datechar="creation" normal="1989/1989" type="inclusive">1989 -</unitdate>
+            <physdesc id="aspace_5fb361bcc85510c4ec17d077515e2663">Typescript document 28 cm. 215
+              leaves</physdesc>
+            <container id="aspace_4f5957ce8e6f50aab48cf735dee44424" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_45b3aa9469e509a7d8db92c3e775d0d8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Title from cover sheet</item>
+              <item>Internal title: Bibliographical Data on Tallis's <title render="italic">London
+                  Street Views,</title> 88 parts, 1838-1840</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ee2d4b6a4142195c2d4a32e00cad9857">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transfer. Book Department, Lilly Library. <date normal="1989">1989.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_daedb4e5f0aba936203d97513d90bf2c" level="file">
+          <did>
+            <unittitle>Baha'i World Center Library. To Walbridge, John.</unittitle>
+            <unitdate datechar="creation" normal="1990-05-03/1990-05-03" type="inclusive">1990, May
+              3 -</unitdate>
+            <physdesc id="aspace_852ed8e7e47d9123c9f418f2a23eb184">Letter 1 p.</physdesc>
+            <container id="aspace_c7f4b9fe4c68285bd21bd0a1f2bd8638" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_df2b92c0e1d06a91c493e128964490cd">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Miller, William McElwee's <title render="italic">The Baha'i faith:
+                  its history and teachings</title> (Main Library holding)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c8227a3d68468f2d7b31a49c796efe9b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="2007">2007.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8a9f03d9632b43c2a035538b839e8450" level="file">
+          <did>
+            <unittitle><persname>Gordimer, Nadine, 1923- , author.</persname>To Edward Callan. "I
+              was so pleased and touched to have your letter..."</unittitle>
+            <unitdate datechar="creation" normal="1991-11-25/1991-11-25" type="inclusive">1991,
+              November 25 -</unitdate>
+            <physdesc id="aspace_dbeab40f39f0d3c81ad2e37babccb575">Autograph letter signed 1 p. 10.5
+              cm.</physdesc>
+            <container id="aspace_5feab0fa53c8aea427f0f83b0d1b9386" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_b35599372fe3859b4380147ef1090cb5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Written on printed card of "...thanks for your congratulations..."</item>
+              <item>Date from accompanying envelope</item>
+              <item>Accompanied by two photographs of Callan and Gordimer with others</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_5c66a6cb50aff88df93d7e96cc060110">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Edward Callan, Kalamazoo, MI. <date normal="1994">1994.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5ebc69d8b0a858512577ae0985022009" level="file">
+          <did>
+            <unittitle><persname>Gordimer, Nadine, 1923- , author.</persname> 7 Frere Road,
+              Johannesburg 2193, South Africa. To Anne Mytton, The London Library 150th Anniversary
+              Appeal, London. "I am happy to respond with the manuscript of a story, L,U,C,I,E.
+              (Yes, the commas are intentional!)...my most recently-written story..."</unittitle>
+            <unitdate datechar="creation" normal="1992-11-04/1992-11-04" type="inclusive">1992,
+              November 4 -</unitdate>
+            <physdesc id="aspace_a3aac909c6db0eafd811762c21948310">Typescript letter signed 1 p.
+              29.7 cm.</physdesc>
+            <container id="aspace_a864462af4b9411e24d750913d735cc5" label="box" type="box"
+              >9</container>
+          </did>
+          <scopecontent id="aspace_97bb82d47a26857e07fbe57a7fa26f94">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by story - typescript document 9 p. 29.7 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2c7059de41c95d94387309d9ff46b84a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Bertram Rota, Ltd. London, England. <date normal="1993">1993.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_20f20113a246c8f3eaebbc68f5fdcfa5" level="file">
+          <did>
+            <unittitle>Man in overcoat taking a drink.</unittitle>
+            <unitdate datechar="creation" normal="1900/1999" type="inclusive">20th century
+              -</unitdate>
+            <physdesc id="aspace_ac18f7a2446b7fab6566a3d6c2b8bd8c">Black and white photograph 19 x
+              23.5 cm.</physdesc>
+            <container id="aspace_6ac671dae6686a913207e20307fe28d1" label="box" type="box"
+              >9</container>
+          </did>
+          <acqinfo id="aspace_694b85db3e31b04b87a0428c8b74a2d9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Indiana University Archives, Bloomington, IN 47405. <date
+                normal="1988">1988.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_51c3de77d0ac49e2a1f3c3bbe02703ed" level="file">
+          <did>
+            <unittitle>Undated - Beattie, Carol, author. To Dr. Linsley, St. James Episcopal Church,
+              Atlantic City, NJ. Praises clergymen and refers to sales of her book.</unittitle>
+            <physdesc id="aspace_41c1cc8df2642ad3b0547371c4580111">Letter signed 4 p. 14
+              cm.</physdesc>
+            <container id="aspace_0f5db0af62cf322b913d9c4de15fcdb4" label="box" type="box"
+              >10</container>
+          </did>
+          <acqinfo id="aspace_7cd3375d89a74e0aed69a141f9eb1220">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Mrs. Robert E. Burke, Bloomington, Indiana. <date normal="1952"
+              >1952.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_47ff90798ab0b173f73c7a36a094a03f" level="file">
+          <did>
+            <unittitle>Undated - Beltran, Luis, 1932- , professor. El Libro de Luis
+              Vilamor.</unittitle>
+            <physdesc id="aspace_c2d7b488ea1e5be40341c81b831008c0">Typescript document signed 169 p.
+              28-31.5 cm.</physdesc>
+            <container id="aspace_7bfc52aaeae10d7a27370e19ef0520da" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_f44943de260bd5448ce009d31c94903b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Heavily corrected in colored inks and pencil</item>
+              <item>Includes preliminary note omitted in published version</item>
+              <item>Lacks pages 191-212 of published work</item>
+              <item>Accompanied by note entitled El Berraco on manila folder</item>
+              <item>Published as: <title render="italic">El Fruto De Su Vientre.</title> Mexico,
+                Samo, 1973 (Main Library PQ6652 .E5 F94 1973).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8dcac2e84295ab87f183ed76c535b158">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Luis Beltran. Indiana University, Bloomington, Indiana. <date normal="1981"
+                >1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_75a9f1675ec6b696b8a7258a048442c4" level="file">
+          <did>
+            <unittitle>Undated - Bill of sale in French. For eight items, including silver pieces,
+              in quantities of one to 24 for 25.36 francs.</unittitle>
+            <physdesc id="aspace_a5b60041828c80a5255f23cfcc028f67">Autograph document signed 1 leaf
+              22.5 cm.</physdesc>
+            <container id="aspace_8deac77d7b4401225ee7f7a144d83348" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_1f694fd8f5449c83ebf5e7073ecb7aee">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Pierre Bayle, <title render="italic">Oeuvres diverses,</title> Vol.
+                III (Lilly CT95 .B31802 1731).</item>
+              <item>Signature not deciphered</item>
+              <item>Partial watermark: fleur-de-lis</item>
+              <item>Includes transcription</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_61b1f8b18885ea516e5caa9202c797ce">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1976">1976.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c7d27980496b2ee04ddb62b666ff1d4f" level="file">
+          <did>
+            <unittitle>Undated - Re: Biondo. Note in Italian regarding Biondo, presumably addressed
+              to Vincento Angeli.</unittitle>
+            <physdesc id="aspace_58f5a3d904ffaaf2f6a705ab62ff0c57">Autograph document 1
+              p.</physdesc>
+            <container id="aspace_6105a6e52c8c3ce341b858202563333b" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_826576b79ebab166488a81012159870c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Flavio Biondo, <title render="italic">Blondi Flaiui forliuiesis
+                  historiaru...</title> Venice, 1483 (Lilly DG76 .B5).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_1b9c4022068ff43bd062ba01cc35101a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1980">1980.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_35cc41ae437f3b2a470775089ae7c4d6" level="file">
+          <did>
+            <unittitle>Undated - Brief note in French mentioning Lagrange, "bonne discipline et des
+              droit."</unittitle>
+            <physdesc id="aspace_bb7dcc5f8c9d63e1520fc36d3ffdb813">Autograph note 8.6 cm.</physdesc>
+            <container id="aspace_85a1f8f5ec65eb3e1de64ee18d835c3e" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_b6b01a7f7649a0678cbef94195dae35e">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Six lines in ink</item>
+              <item>Lagrange may be French mathematician Joseph Louis Lagrange, 1736-1813 (EB 14th
+                ed., 13:593)</item>
+              <item>Verso bears random math calculations - "obligeante?"</item>
+              <item>Removed from <title render="italic">Les reglement des manufactures et teintures
+                  des etoffes...</title> Paris, C. Saugrain, 1701 (Lilly HD9862.5 F7 1701)</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_748e6d11f24a53db8dff6537ac7c8626">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1980">1980.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4bb7c64a2c4bcaca767f23004aba5845" level="file">
+          <did>
+            <unittitle>Undated - Burton, John, 1696-1771, doctor of divinity. The genuiness of Lord
+              Clarendon's History of the rebellion printed at Oxford vindicated. And Mr. Oldmixon's
+              misrepresentaions disprov'd...</unittitle>
+            <physdesc id="aspace_1a74bc4b2d48343c435a79c3874f0c96">Document 51 p. 24 cm.</physdesc>
+            <container id="aspace_ee25f60ed56771def596216e7515dfb2" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_192058cb63efe4004341c831d01e1586">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Bookplate of Cecil Grantham Page mounted on front end paper</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9b05eaa84d17b41c1c623e7b0b162064">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Thomas Thorp, dealer, 149 High Street, Guilford, Surrey, England. <date
+                normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_07812d674058333b3b3be370ff33243e" level="file">
+          <did>
+            <unittitle>Undated - Catholic Church. Liturgy and ritual. Music, litanies and rubrics
+              for festival processions.</unittitle>
+            <physdesc id="aspace_a67cac33c0d6fe180f39403b4206e47f">Autograph document</physdesc>
+            <container id="aspace_f907d681f5345bcd2492ccbdb522d1e1" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_f7e067490f4bc6e682242f9cb28cabde">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Catholic Church. Liturgy and ritual, <title render="italic"
+                  >Processionale ad usum sacri et canonici...</title> Verdun, C. Vigneulle, 1727
+                (Lilly BX2049 .P963 1727).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e34db3908d52e38dbf4f86cce52c2083">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1980">1980.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_870fce43805a42e12cd228d1095f47ba" level="file">
+          <did>
+            <unittitle>Undated - Clemens, Cyril, 1902-?, author. Kirkwood 22, Missouri. To "Dear
+              Director." "My inscription speaks for itself."</unittitle>
+            <physdesc id="aspace_11ed1b8e2940f445f3b2655dc6fa96b8">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_c7648ba5f7029711c037c47658420681" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_a07b6ba4bb4177dc0c87fcb6c86eddf8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from C. Nelson Sparks, <title render="italic">One man--Wendell
+                  Willkie.</title> New York, Rayner Publishing Company, 1943 (Lilly E748 .W7
+                S73).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_dd6b67d0d17623a9de5595ff45702f88">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_68bcadead9a8dfe390c37abb42a50082" level="file">
+          <did>
+            <unittitle>Undated - Contemporary biographical notices of John Fell and William
+              Levett.</unittitle>
+            <physdesc id="aspace_86e4d6415ed7c893c49cba37c91554b9">Holograph note 1 leaf</physdesc>
+            <container id="aspace_e82d22de7056a147b4319023b4d28ec6" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_4903c5d11dfe3c9e765366471ed8b077">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Anthony Wood, <title render="italic">Historia et antiquitates
+                  universitatis Oxoniensis.</title> Oxonii, E theatro Sheldoniano, 1674 (Lilly LF514
+                .W87 H6).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_fe7e68cfc51e29cf60ebb5a87213e4b8">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1978">1978.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c55feb064953ac7a07ccaf3e23c8fc9d" level="file">
+          <did>
+            <unittitle>Undated - Contemporary cost sheet for a work project. "delivered at
+              Wimbleton."</unittitle>
+            <physdesc id="aspace_d398cb6df41c9a03f55e3114749ad253">Document 1 p. 19.6 x 10.5
+              cm.</physdesc>
+            <container id="aspace_c5a701cc3db199c80080cd760237a69d" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_b849ec0a029ddd17fb43d4166880589c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Gives costs for horses, drivers, carriages, and "ten load of manure per
+                acre"</item>
+              <item>Has 1/4 of Britannia watermark</item>
+              <item>Removed from Richard Weston, <title render="italic">Tracts on practical
+                  agriculture and gardening...</title> London, S. Hoops, 1769 (Lilly HD1925
+                .W3).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2d83770283f783f64ca958e37ed6cc22">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5d08a7f02cbdd2882a030d12cd50c35a" level="file">
+          <did>
+            <unittitle>Undated - Crowley, Aleister, 1875-1947, author. Inscription on front fly-leaf
+              of and marginalia in F. W. Crofts'<title render="italic">The Pit-prop
+                Syndicate...</title> London, W. Collins, 1922.</unittitle>
+            <physdesc id="aspace_02b4ea8352bc5d0a9ab9426b7fbfe66e">Autograph document signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_2ad9c952a86ba8f200d2908de477509c" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_b360cfc867a042532a71cceaa23dc4cd">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Lilly PR6005 .R73 P6</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6ef8f9a83789b71b462b8f5a83267ca1">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1958">1958</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_07f5c2dfb349b1677aa772b6f6493892" level="file">
+          <did>
+            <unittitle>Undated - Description of the cure by laying on of hands as found in the
+              thirteenth century Norse Edda and in the histories of the Kings of France.</unittitle>
+            <physdesc id="aspace_eea3e2ff6d8c0ba41ce5e16cffc4b976">Autograph document 4 p. 23
+              cm.</physdesc>
+            <container id="aspace_0ec515a5277075a1dbab244e1b4b32ba" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_a6a28f772c1fe4048154fc06dae29775">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Unsigned manuscript pages in a nineteenth century hand</item>
+              <item>Removed from Richard Wiseman, <title render="italic">Several Chirurgicall
+                  Treatises.</title> London, printed by E. Flesher and J. Macock for R. Royston,
+                1676 (Lilly RD30 .W8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6485bed4d79cca80d06e6f3ce434641e">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_cceb723bffd99943238862edf25c7aed" level="file">
+          <did>
+            <unittitle>Undated - Drew, John, 1853-1927, actor. The Brunswick, Boston. To Dear
+              Higginson. Accepts an invitation, thanks him for his praise of the play "Rosemary,"
+              and speculates on the reasons for its lack of popular success.</unittitle>
+            <physdesc id="aspace_8ecf55df15da88a20f910a459b6a5f78">Autograph letter signed 4 p. 20
+              cm.</physdesc>
+            <container id="aspace_ec3fdcc0d01984f7bfbc41f8ea5f3f97" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_0996a63ca8590bf7e595c330e8cffea4">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Douglas Taylor, <title render="italic">Autobiographical sketch of
+                  Mrs. John Drew,</title> New York: Scribner's, 1899 (Lilly PN2287 .D7 A3
+                1899).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_8c1531d380e236963d35b1a9f8c45a23">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1976">1976.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_844dd888788d0f4a6661593c09dacac4" level="file">
+          <did>
+            <unittitle>Undated - Dufour, Charles, ?-1679, abbé d'Aulnay et curé de Saint-Maclon de
+              Rouen. Lettre d'un curé de Rouen a un curé de la campagne sur le procedé des curez de
+              lad(ite) ville contre la doctrine de quelques casuites pour servir de refutation a un
+              libelle intitulé, Response d'un theologien &amp;c.</unittitle>
+            <physdesc id="aspace_83c4e802bdc563df084232043a1772b7">Autograph document 12 p. 22
+              cm.</physdesc>
+            <container id="aspace_3f5f7266be46115b11922d1230d39307" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_fd305d80cf6d8258ea1f7b250134f053">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Blaise Pascal, <title render="italic">Les provinciales...</title>
+                Cologne, Pierre de la Vallée, 1657 (Lilly BX4720 .P7).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_3b934645bcd2b282bdee644f91b1771c">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_31e7e44c6704a943fa78e2c9370bc5da" level="file">
+          <did>
+            <unittitle>Undated - Ellis, Elaine, 1918?- , actress. To Francis L. De VAllant. "Tobacco
+              Road should be proud of such an ardent admirer..."</unittitle>
+            <physdesc id="aspace_c4f92f7d3702494e0e07284aa8bd548e">Autograph letter signed 2 leaves
+              20 cm.</physdesc>
+            <container id="aspace_788f637e83e2ceaf642a3403a32fca70" label="box" type="box"
+              >10</container>
+          </did>
+          <scopecontent id="aspace_30d39f43032b04f615c3a3048e300c22">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Monogrammed E E in blue</item>
+              <item>Mounted in Tobacco Road: a scrapbook the most discussed play in the history of
+                the American Theater, opened at the Masque Theater, December 4, 1933 (Lilly PS3521
+                .I6996 T62).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_97158927a25b072f2f40c98f88ca74c5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1972">1972</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1b50ac08c313c157d30afdfcbc872dc8" level="file">
+          <did>
+            <unittitle>Undated - Felix, archduke of Austria, 1916- . Signature.</unittitle>
+            <physdesc id="aspace_6f4c4579a443ceba531c3a57b3412ae3">Signature 1 p. 14 cm.</physdesc>
+            <container id="aspace_ebd4f37f01eae3d63c1981828fe2df56" label="box" type="box"
+              >11</container>
+          </did>
+          <acqinfo id="aspace_6d1fa710f9d8ba9247640f903cd12348">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Dwight L. Smith, Indiana University, Bloomington, Indiana. <date normal="1948"
+                >1948.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6e3a041a249a73b2897606878cf52511" level="file">
+          <did>
+            <unittitle>Undated - <persname>Greenough, James Bradstreet, 1833-1901,
+                philologist.</persname> To D. C. Wells. Regrets that he has not had time to digest
+              Schleicher probably August Schleicher Compendium der vergleichenden grammatik der
+              indogermanischen sprachen... into convenient form but hopes to do it within the next
+              year.</unittitle>
+            <physdesc id="aspace_f2a9ea6324fff08a7826f712a2ff8964">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_3498305cd4195a100b69463c2a934ad0" label="box" type="box"
+              >11</container>
+          </did>
+          <acqinfo id="aspace_8a38fb79f7a90594272589dcd569ca3e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source and date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_ab31b637a114779bc7893697f3e5ec78" level="file">
+          <did>
+            <unittitle>Undated - Journal of the latter part of a Continental tour. The journal
+              begins at Cologne and proceeds via Aix la Chapelle and Maastricht to Brussels where
+              they run out of money. Eventually funds arrive from England and they continue their
+              tour including a visit to the field of Waterloo, where skulls and bones are still
+              lying about. The journal ends with sailing from Calais.</unittitle>
+            <physdesc id="aspace_77ad79419d8d6a6a3ce6834d4c5bf69f">Autograph letter 25 p. 20
+              cm.</physdesc>
+            <container id="aspace_2e27ccc7920873040df4232bd5f950af" label="mixed materials"
+              type="bound">Bound.</container>
+          </did>
+          <scopecontent id="aspace_4b6acae60be5ec7a4d4aced27beb23f9">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Sixty-four blank pages</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_0fc323cadfa0f1b4efd49b0f5bb21035">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Henry Bristow, Ltd., Ringwood, Hants, England. <date normal="1974"
+                >1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_d00e8dec10a89824d8f0056c14f0d3a8" level="file">
+          <did>
+            <unittitle>Undated - <persname>Keene, Laura, 1826-1873, actress.</persname> Photograph
+              of Laura Keene?</unittitle>
+            <physdesc id="aspace_7204d79b407160856a6ace26aa19c02f">Photograph 6 x 10 cm.</physdesc>
+            <container id="aspace_df975aee866b46242e07ada9d379c389" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_5b71533a8a07ccbedaa20b74596cfb34">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from John Creahan, <title render="italic">The life of Laura
+                  Keene.</title> Philadelphia, The Rodgers Publishing Company, 1897 (PN2287 .K5 C9
+                copy 2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4f196107198f9aaa1e4ad84f805c3a0f">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1968">1968.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_21f31fe103f569ea0757a6808f0bf611" level="file">
+          <did>
+            <unittitle>Undated - <persname>Lewis, Sir Watkin, lord mayor of London.</persname> To
+              Mme. Wright. Invitation to dinner.</unittitle>
+            <physdesc id="aspace_6e48722d75bccf7098d6f542da221aa8">Autograph letter signed 1 p. 16
+              cm.</physdesc>
+            <container id="aspace_4358ecfc53ae55f2c9adcb7a44fab464" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_81bfbc0c35d95efbbfca3325d8c56328">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted in Vincenzo Lunardi's <title render="italic">An Account of the First
+                  Aerial Voyage in England...</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_2a4e2189ccfa38ca8697e592151f0a22">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_f1ad2f7325e1a1582bca27367e002dc6" level="file">
+          <did>
+            <unittitle>Undated - Louis Principe de Parme (i.e. Louis I, king of Etruria), 1773-1803.
+              To Francis James Jackson, minister plenipotentiary of England. "Vous m'avez surpris de
+              matin... que vous partier bientot pour Madrid..."</unittitle>
+            <physdesc id="aspace_f5306a52bb2a0790b04ad012fcf0d0c7">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_6fbcc312d63acd2f61797435a974bac1" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_26eacbde14659e08f2be7a34ceb66f8b">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+              <item>Bears red wax seal</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e6fa2ebc770861d211f8e7775849f3bc">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e494ce20a93fafea4c138a7123dbe02a" level="file">
+          <did>
+            <unittitle>Undated - Louis Principe de Parme (i.e. Louis I, king of Etruria), 1773-1803.
+              To Jackson, Francisco Jayme (i.e. Francis James), Ministro Plenipotentiario de la
+              Corio de Inglaterra [sic]. Speaks of "d'un certain<title render="italic"
+                >Forster</title> marchand de productions d'histoire naturelle..."</unittitle>
+            <physdesc id="aspace_96b50494fffa58b6d5d4ae6a038e8cec">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_5ced2961faa9721a1f04b6da38dac188" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_0f904f36e4239438d53b867e684ee176">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>French</item>
+              <item>Bears red wax seal</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_80477e6d5b1152eca8570ee5ae9a2082">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_21a4801b3a476ca9ee5d06acecd976e6" level="file">
+          <did>
+            <unittitle>Undated - <persname>Lowden, R. C., aeronaut.</persname> To "Sir." Objects to
+              playing the part of "Serjeant Dubb" in a play.</unittitle>
+            <physdesc id="aspace_b2457654f1f300181df482cc4aa28ef7">Autograph letter signed 2 p. 23
+              cm.</physdesc>
+            <container id="aspace_281fdf4bac0109a81947cc8049c2651a" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_f7041f5d38ba85a8133033f35da56c59">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Signed "R. C. Stapleton"</item>
+              <item>Removed from Vincenzo Lunardi's <title render="italic">An Account of the First
+                  Aerial Voyage in England...</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9b0a9e4970fb7615d669f8d0e85c6ab0">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_18802f5b892982a5d2d35e4e0c6ee069" level="file">
+          <did>
+            <unittitle>Undated - <persname>Ludwig, Emil, 1881-1948, biographer.</persname> Moscia,
+              Ascona, Scweiz. To Maurice Eden Paul. "...I send you 2. chapter. also no more than 9 -
+              10,000 words...All depends of you and your wifes ART! All depends of the style...
+                <emph render="underline">No Bible-Style...</emph></unittitle>
+            <physdesc id="aspace_ffbb8c8a006da82aba3b3f900c46c0e6">Autograph letter signed 3 p. 21
+              cm.</physdesc>
+            <container id="aspace_bd815b9786ec43398dee04c239ca3522" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_d063e70f0c16552294c2fb215e5a57ff">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Dated 22/9</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d6320c96fb4446de4c86f488dbbec8c2">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ingo Nebehay, Vienna, Austria. <date normal="1972">1972.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e27b561f89948a187dc84c7828381a54" level="file">
+          <did>
+            <unittitle>Undated - Martinus Lutherus: signature inscribed in a Latin Vulgate
+              Bible.</unittitle>
+            <physdesc id="aspace_f1ffba5d77bde56af52835bbad03c7f7">Printed document signed 1 leaf 29
+              cm.</physdesc>
+            <container id="aspace_9c44a5aeb7859d0cc57c1fa378ab6f6d" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_8c76a3583acba935df64f7b9f2f33687">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Inscribed on leaf 2 of Prologus primus Venerabilis fratis Nicolai de Lyra...of
+                the Latin Vulgate Bible (Lilly BS75 1485 Vault), formerly owned by Robert
+                Clutterbuck, 1772-1831, topographer of Watford, England</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b1968de529c98a19b63c2c67546f6fc9">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Frances and George Ball Foundation from the estate of Elisabeth W. Ball,
+              Muncie, Indiana. <date normal="1986">1986.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c51c435a27cc1ce97a8ccd356b07d0ff" level="file">
+          <did>
+            <unittitle>Undated - Miscellaneous document concerning Christian life, in three
+              parts.</unittitle>
+            <physdesc id="aspace_9303bb2de24a5314c01763550f372bd5">Autograph document 114 p. 10
+              cm.</physdesc>
+            <container id="aspace_bb53fac8cc85feffa5cb5967d594d5ce" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_32c142d68e4e26a7b6a3d268fb71d3a6">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Part I: Missal - in German, 57 p.</item>
+              <item>Part II: Laudabile e bene...(Latin) which offers Example 87, 89, and 100, 24
+                p.</item>
+              <item>Part III: Quida milos Dialectes : Lausanensis Venetum circa Montes Alprum per
+                gens familiam...(Latin) which offers, among other topics, a view of Nigromantia, 66
+                p.</item>
+              <item>Between Parts II and III is bound the printed work: <title render="italic"
+                  >Weegzaiger: wie ein Feder den wahren Christlichen Glauben erkennen...</title>
+                printed in Munich by Lucas Straub in 1652, 215 p.</item>
+              <item>Inside front cover: Conventus Hradioninnis?</item>
+              <item>On flyleaf: the date Apr. 25, 1663</item>
+              <item>On printed title page: 1759</item>
+              <item>Bound in contemporary vellum, varnished spine with number 321, leather straps or
+                ties missing</item>
+              <item>From the Olomouc Collection</item>
+              <item>Shelved as Lilly BV4801 .W39</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_65e724b859d7214f02a4514fb30a8b1d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Transferred from Lilly Library Book Department. <date normal="1974">1974.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a9a7c261b2ec69f1d81a2554f122dc42" level="file">
+          <did>
+            <unittitle>Undated - Miscellaneous Simaese stories and legends.</unittitle>
+            <physdesc id="aspace_3ac8e55875c45540accf0efd6a048c8a">Document 7 &amp; 64 leaves 5.5 x
+              55 cm.</physdesc>
+            <container id="aspace_ff24a99493676a76b15d2833946dc708" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_434336a8c961a97044400f159b32cd8a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Written on palm leaves edged in gold</item>
+              <item>Each segment tied with cord through center hole in leaves</item>
+              <item>Shelved in blue oblong box</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_e423d0adc5394723eb74cf6b39f00ebb">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Rev. Francis W. Grossman, Indianapolis, Indiana. Date unknown.</p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_c74635ac80e8cf371e022dadbc150dfb" level="file">
+          <did>
+            <unittitle>Undated - Monteith, Mina M. E. To "Dear Sir." Leaving Venice; "meant all day
+              yesterday to leave the Stones of Venuce."</unittitle>
+            <physdesc id="aspace_244775f345f81365f4c8c0cc53078ab0">Autograph letter signed 2 p. 21
+              cm.</physdesc>
+            <container id="aspace_9119a5eda57b07c54097c18a186317ae" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_22bfdf88f41182461d01f9c095d74b2a">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from John Ruskin's <title render="italic">The Stones of
+                  Venice...</title> London, Smith, Elder, 1853 (Lilly NA1121 .V4 R9 1851 V.2 copy
+                1).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_97ff9a0646993fe9a3ed23e6e80e1dc6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1951">1951.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_de620b3c86720af5df744235afd44a0b" level="file">
+          <did>
+            <unittitle>Undated - Muhammad, the Prophet. A fragment of the sayings of the
+              Prophet.</unittitle>
+            <physdesc id="aspace_68e0e6ee9341842b6f72cf66a3ca7685">Autograph document 1 p. 9
+              cm.</physdesc>
+            <container id="aspace_28cfff938920f396491fafe1fdacd95a" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_8bfcecb59102cb520cf8e445c858a3f8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Arabic</item>
+              <item>Text in black with red marks in an unknown hand.</item>
+              <item>The left margin bears ink stains and has rounded corners.</item>
+              <item>Removed from Huccatlar. 18th century.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_073badaef0af085a335980f3056dd617">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a4180db6603028191dae08c0eb8d9584" level="file">
+          <did>
+            <unittitle>Undated - Omar Khayyám, ca.1025-ca.1123, poet. Rubaiyat of Omar Khayyám,
+              collected and translated from the original Persian by H.M. Schroeter and Isaac
+              Dooman.</unittitle>
+            <physdesc id="aspace_517d11c268c067edd5190c37d3c8276d">Autograph document 121 p. 29
+              cm.</physdesc>
+            <container id="aspace_88a238f108e37f98d4aae3951449d394" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_6ddc22575afb05c7d443a49219ec2ee5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Introduction and notes for thirty-three of the 179 quatrains translated.
+                Published as <title render="italic">Rubaiyat of Omar Khayyám, translated from the
+                  original Persian</title> by Isaac Dooman. Boston, Richard G. Badger, 1911.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_5d600ed49b44da33dfcc07f1620c1aed">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. George Ball estate, Muncie, Indiana. <date normal="1965">1965.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_9a3bdddde2f43be1b1f81463cb7e18ce" level="file">
+          <did>
+            <unittitle>Undated - <persname>Patin, Guy, 1601-1672, physician, author.</persname>
+              Borboniana, ou Conversations de Nas, Bourbon le jeune de Bar sur Aube.</unittitle>
+            <physdesc id="aspace_7405c04f66b2a8639ac12cad3b2047b7">Document 178 leaves 23
+              cm.</physdesc>
+            <container id="aspace_8da1661255fca0b1f01ddf036acb4758" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_a2cc23655b209ad5a62953049a445662">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>For description of original ms. see <title render="italic">Biographie
+                  Universelle Ancienne et Moderne...</title> Paris, Michaud, 1812. V:352-343.
+                Published under title: "Bourboniana, ou Fragments de littérature et d'histoire de
+                Nicolas Bourbon" in vol. II of François Bruys' <title render="italic">Mémoires
+                  Historiques Critiques et Littéraires...</title> Paris, J. T. Hérissant,
+                1751</item>
+              <item>Contents: 1) Bourboniana, ou Conversations de Nas. Bourbon le jeune de Bar sur
+                Aube, leaves 1-158; 2) Extrait du...Jugement de tout ce que a esté imprimé contre le
+                cardinal Mazarin puis le 6e janr. jusqu'à la declaration du parlmt., April 1649, par
+                Gabriel Naudé, leaves 163-171; 3) Extrait...Jugemt. &amp;c...M.
+                Naudé...bibliothécaire du cardinal Mazarin. 1re edition, leaves 172-173; 4) Recueil
+                des pieces imprimes...1649, 177-178.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_25f424cff4d6f24c9dc3762ceae3943b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Export Book Company, Preston, Lancashire. <date normal="1947"
+              >1947.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8b029a95f0f14fd2d79ae34412996e8d" level="file">
+          <did>
+            <unittitle>Undated - "...personal account of the Battle of Jutland as observed by the
+              Executive Officer of H.M.S. WARSPITE..."</unittitle>
+            <physdesc id="aspace_ce4fd1c4e172fa10c6dde3c42ce9c338">Typescript copy 17 p. 27
+              cm.</physdesc>
+            <container id="aspace_2c2597ad04dce4dcb67ed1df52482517" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_91517a31bfcdb3b0461c244f8f3906b0">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Describes the events of 1916, May 31-June 1</item>
+              <item>Preliminary note indicates that this account be "treated as confidential"</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_b10f33150d737655dc44e8a626b873fc">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Josiah Quincy Bennett, Lilly Library, Indiana University, Bloomington, Indiana.
+                <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1485abdb6ca5b9971dabc564a37a2bdb" level="file">
+          <did>
+            <unittitle>Undated - Philosophy and Culture, by an unidentified writer, who offers
+              advice to "any young Charmides..."</unittitle>
+            <physdesc id="aspace_b99f2831bc82ff9524ab3d37ec91563c">Autograph document 16 p. 29 and
+              25 cm.</physdesc>
+            <container id="aspace_2500c4031890451455f5a27ab432104c" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_bd6d3d771f248d39fe8c6a5df753104c">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In black ink with many corrections</item>
+              <item>Part A: p. 1, 4, 5, 8, 9, 10, 11, 13 (bis), 23, 24, 25: "the earlier part of
+                this book will be devoted to an analysis of the true nature of what we call
+                culture"; page 23 bears note in pencil about "3 Extra pages written for...of
+                Poetry..."</item>
+              <item>Part B: Culture and Painting, p. 3 and 11: "It is the same with Nicholas Poussin
+                that majestic brownish-green foliage extends above the alter of the sacred
+                groves..."</item>
+              <item>Part C: Culture and Philosophy, p. 11 and 19 - on lined paper: "the present
+                writer's advice, then, to any young Charmides..."</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_4c7fc6afcb13e1a2610ef9b0f9b944be">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. W.A. Gumberts, Evansville, Indiana. <date normal="1962">1962.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8ac0e96f1bfb6109a3422ee1c1e6ee16" level="file">
+          <did>
+            <unittitle>Undated - Photograph of Phineas Taylor Barnum, 1810-1891,
+              showman.</unittitle>
+            <physdesc id="aspace_87241f5d72dbb74ca7b8395c37372e0a">Photograph 15 x 10.5
+              cm.</physdesc>
+            <container id="aspace_b464b4087cd62f42c4adde7122f8aaa7" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_ad57d566779889e15455107dcd3b0b89">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Made by Warren's, 289 Washington Street, Boston, Mass., under the
+                superintendence of Mr. L. B. Heald</item>
+              <item>Half-view photograph</item>
+              <item>Removed from <title render="italic">The Life of P. T. Barnum; written by
+                  himself.</title> New York, Redfield, 1855 (i.e., 1854) (Lilly GV1811 .B24
+                1854).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_6f468f7232f7fe3e8c968c7a36ab6823">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1981">1981.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_6298ea1bf9c3cb014914b78a5fa546a3" level="file">
+          <did>
+            <unittitle>Undated - Portion of manuscript on alchemy with frequent references to
+              Raymond, accompanied by an incomplete manuscript on natural philosophy.</unittitle>
+            <physdesc id="aspace_d6552d52c73f7d5e1f5ef1acb0d0d4c4">Autograph document 32 + 6 leaves
+              29 cm.</physdesc>
+            <container id="aspace_f7dfa5110a2da6058f6e1305063e98ab" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_eacf71cefeb4c622d86e811cc12a2fc8">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Leaves numbered 47 to 78</item>
+              <item>Sewn in two gatherings</item>
+              <item>In French with a few lines in Latin, leaf 53r</item>
+              <item>Marginal note in Spanish, leaf 61v</item>
+              <item>Contains portion of the first book, second book complete, and portion of the
+                third book by the same author (unknown)</item>
+              <item>Reference to the library of the Valois family, leaf 73r</item>
+              <item>Accompanied by 6 unnumbered leaves in the same hand as above on the subject of
+                natural philosophy by an unknown author with marginal notes in Spanish</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_d0184970fe769e26e7c220cdcdabb08a">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Bernardo Mendel, 8 West 40th Street, New York, N.Y. 10018. <date
+                normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4ced0069116b62f5c43874d89c5533f3" level="file">
+          <did>
+            <unittitle>Undated - <persname>Rankin, Jeremiah Eames, 1828-1904, Congregational
+                clergyman.</persname> God be with you till we meet again.</unittitle>
+            <physdesc id="aspace_2079e104f037fdc2c7de0e923b8347ad">Autograph document signed 2 p. 32
+              cm.</physdesc>
+            <container id="aspace_681be55d2e1c93cca39ada593b6f6b19" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_5acf0a1f335716f23fbdfb179338f3d5">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by 1) Biographical sketch of Jeremiah Eames Rankin, c.1878
+                typescript document with corrections. 6 p. 26 cm.; 2) Clarence Saunders Brigham to
+                Carroll A. Wilson, September 12, 1941; 3) Photograph of Jeremiah Eames Rankin,
+                autographed on verso; 4) Printed copy of <title render="italic">God be with you till
+                  we meet again, illustrated by Helen P. Strong...</title> n.p., n.pub., n.d.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_700bf53b05a3c7cae1e14a874e6bb72d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Scribners, New York, New York. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_fb93ecb5bd48fa1ac221d6ac5a745b61" level="file">
+          <did>
+            <unittitle>Undated - <persname>Ricord, Philippe, 1800-1889, physician.</persname> To
+              "Mon cher ami."</unittitle>
+            <physdesc id="aspace_7d2cebe856837e55f0fc05fff664793d">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_2c8676767f7b929519c687d5618048f1" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_ea65772f319eb8be1ed5fd35dafb8c78">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted on title page in Ricord's <title render="italic">Traité pratique des
+                  maladies vénériennes...</title> Paris, Librairie des sciences médicales, J.
+                Rouvier et E. Le Bouvier, 1838 (Lilly RC201 .R55).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7ec3d7c182c766e2fc2c3f47b60326a7">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Josiah Kirby Lilly, Jr., Indianapolis, Indiana. <date
+                normal="1956">1956.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_03bc6a875925a69e0e523873e3c4e2a8" level="file">
+          <did>
+            <unittitle>Undated - <persname>Robertson, Etienne Gaspard, 1763-1837,
+                aeronaut.</persname> St. Petersburg, Russia. To "Son excellence M. le président et
+              les respectables membres de l'Academie Akademia nauk." Suggesting that the academy buy
+              his balloon and the equipment for it.</unittitle>
+            <physdesc id="aspace_4494281d32de286bf790dd1af5d31df1">Autograph letter signed 2 p. 25
+              cm.</physdesc>
+            <container id="aspace_f2111221b5ab31e5b05169c3598d2b77" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_43fc2f1dbd743743efa657c59cbe686d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Vincenzo Lunardi's <title render="italic">An Account of the First
+                  Aerial Voyage in England...</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ba1f053af78bfde1e2ab48e70e21e320">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_76922c675c8be6e469d9c355f8f5438d" level="file">
+          <did>
+            <unittitle>Undated - <persname>Scott, Robert Falcon, 1868-1912, antarctic
+                explorer.</persname> To Lady Hoskins. Accepts invitation.</unittitle>
+            <physdesc id="aspace_f243de4cd6d95dcd19d0283780c57fe6">Autograph letter signed 1 p. 20
+              cm.</physdesc>
+            <container id="aspace_f93dee92be0f045e6f9273ee61f2968c" label="box" type="box"
+              >11</container>
+          </did>
+          <acqinfo id="aspace_1c8efc7d69784f0af2ccace7858545f6">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. William M. Adkins, Bloomington, Indiana. <date normal="1961">1961.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_95b93e20a497e0db28a49eff284c8a7b" level="file">
+          <did>
+            <unittitle>Undated - <persname>Scott, Robert Falcon, 1868-1912, antarctic
+                explorer.</persname> 56 Oakley Street, Chelsea Embankment, London, England. To Sir
+              Ernest Henry Shackleton. Refers to note of correction sent to "Daily
+              Mail."</unittitle>
+            <physdesc id="aspace_1dad4c2c846c3ddd3b5fdc628bb98959">Autograph letter signed 2 p. 14
+              cm.</physdesc>
+            <container id="aspace_1782917a384eef9070e146dccbe86152" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_12e05ac5fc30176eb9d8246677a792e3">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Paper watermarked: The Westminster Note</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_57a7223e94a64eabacd8c4ea73efcba4">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift of William M. Adkins, 405 South Jordan Ave., Bloomington, Ind., who acquired it
+              from American Library Service, 117 West 48th Street, New York 19, N.Y. <date
+                normal="1950">Ca. 1950.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 audience="internal" id="aspace_2443e4384bcc8ecb55f85b1668b8b3a4" level="file">
+          <did>
+            <unittitle>Undated - Seven commemorative medals including among other notables: Abraham
+              Lincoln, Hans christian Anderson, Handel, Benjamin Franklin</unittitle>
+            <container id="aspace_c9fc6def83f33d32c91703da31662d39" label="Mixed Materials"
+              type="Box">14</container>
+          </did>
+        </c02>
+        <c02 id="aspace_ef16826baea30fe7f7835d3e5b8a1e93" level="file">
+          <did>
+            <unittitle>Undated - State of the case of the Honor, Signory, Barony, or Lordship of the
+              late Lord Sandys Baron de la Vine which descends to his heirs general.</unittitle>
+            <physdesc id="aspace_b541f928e59c60457e7b55d2c9e37468">Autograph document 4 p. 30
+              cm.</physdesc>
+            <container id="aspace_02d73f1a52d2cba59ff1fe7a1e986975" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_04a677e9b49deb0ee8f7fedd2afd365d">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Draft of the petition of Edwyn Stede, lieut. governor of Barbados, 1685-1689, to
+                accede to the barony of Sandys le Vine, following the death of the 8th baron, Sir
+                Edwyn Sandys in 1700</item>
+              <item>Accompanied by sketch of family tree and references</item>
+              <item>Removed from Sir William Dugdale, <title render="italic">The baronage of
+                  England...</title> London, Printed by T. Newcomb, 1675-76 (Lilly CS421 .A2
+                D8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c8331c125c122115ca3d0fbdb5d034db">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1970">1970.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_4ec89ef4663db92edb7b2d17aab976c2" level="file">
+          <did>
+            <unittitle>Undated - Steel, G. R. Notes on the history of the Covenanters in Scotland
+              and on the life of David Jamison Shaw.</unittitle>
+            <physdesc id="aspace_ed8e147d147080e7713f6429444ac9d1">Autograph document signed 4 p. 20
+              cm.</physdesc>
+            <container id="aspace_3efba18d5a490124de509a8a441d753b" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_20cfd02bf8053c8bb8fe2be64be29056">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">Proceedings of the Convention of United
+                  Presbyterians Opposed to Instrumental Music in the Worship of God...</title>
+                Alleghany, Pa., August 14th and 15th, 1883. Pittsburgh, Myers, Shinkle &amp; Co.,
+                1883 (BX8981 .U5 1883).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_cb978fdddb4fe20bd00bf41a4306e663">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1918">1918.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_83ac6fc2df383cc625a7003ba9be9612" level="file">
+          <did>
+            <unittitle>Undated - The study of history.</unittitle>
+            <physdesc id="aspace_7e6d0a4461801cedfb077ac06f7c4b03">Typescript document 28 p. 26
+              cm.</physdesc>
+            <container id="aspace_c11c876a0db4bd9dfd063ba6c1c9f62e" label="box" type="box"
+              >11</container>
+          </did>
+          <acqinfo id="aspace_e34b94d1660e402bb1f32d237e3fddc7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Transferred from the Main Library, Indiana University, Bloomington, Indiana.
+                <date normal="1939">1939.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_8531d9835d37dfb4058e1209b66b4673" level="file">
+          <did>
+            <unittitle>Undated - The Silvesty Ryan Book. Handwritten journal of healing rituals
+              involving numerology, biblical incantations, burying coins in various cardinal
+              directions at various times of the night, etc.</unittitle>
+            <physdesc id="aspace_5e5887fc4f164d898b57b76d78ffecc7">Autograph document</physdesc>
+            <container id="aspace_c0b26eb0b9fab02b474303422b2fa53f" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_66ed587ea3bf439f391408d860c07288">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Provenance note included from Lawrence Wells, donor: "Enclosed is the old
+                handwritten journal that I discovered in Bloomington in 1987 I believe...I would
+                guess that it was in the house on the SW corner of Park Ave. and Cottage Grove
+                St..."</item>
+              <item>Accompanied by small folded note tucked into back of book</item>
+              <item>Last page reads "Silvesty Ryan Book" (note from donor: "this is either the
+                author, or a "patient" for whom the book was written")</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ac33dc7840cca1d2a82365b69333277d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Lawrence Wells. Brooklyn, N.Y. <date normal="1999">1999.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_5c36ab00eef3b66d38372399a43d60da" level="file">
+          <did>
+            <unittitle>Undated - <persname>Symons, Alphonse James Albert, 1900-1941,
+                author.</persname> London, Eng. To "Dear Sir or Madam." Seeking contributions for "a
+              subscription in Mr. Percy H. Muir's favour to mark his discharge from bankruptcy, and
+              as a slight recognition of his services to bibliography."</unittitle>
+            <physdesc id="aspace_2612d732de08cf53275fedd868e694b2">Mimeographed letter signed 1 p.
+              25 cm.</physdesc>
+            <container id="aspace_10991de55705a957b0b03a94b23077d8" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_da5b899a2a1c2651e6fc1714e6461e97">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Mounted inside back cover of Muir's <title render="italic">Points, second
+                  series,</title> 1866-1934... London, Constable, 1934 (Lilly Z992 .M9 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_ddf1ddded4656cc217457767a04c154d">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1957">1957.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_78a8583415a84734801f7268a0cfd3a2" level="file">
+          <did>
+            <unittitle>Undated - <persname>Tanabe, Mokei, 1688-1768, author.</persname> Nagasaki
+              Jitsuroku Taisei. Deals with politics, religion, foreigners, and the economy of
+              Nagasaki.</unittitle>
+            <physdesc id="aspace_34e9d004e2666b4a641b185b09c33879">Autograph document 266 leaves 17
+              x 24 cm.</physdesc>
+            <container id="aspace_055c465c0da4e8fbf54075cc84a2aa56" label="mixed materials"
+              type="Bound">Bound</container>
+          </did>
+          <scopecontent id="aspace_3efeb123e62499185101c05d19254e32">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In Japanese</item>
+              <item>Blue cloth folder with ivory clasps</item>
+              <item>Notes by and bookplate of C. R. Boxer</item>
+              <item>Volumes V-XII in two, stitched in wrappers</item>
+              <item>Double leaves</item>
+              <item>Title and imprint from Koga's 1928 reprint; preface to reprint, p. 5, states
+                that Tanabe completed and deposited most of the work at the Nagasaki Municipal
+                Office in 1764, and the volumes completed thereafter should be attributed to the
+                office. Kokusho Somokuroku VI, 288, uses the 1760 date of Tanabe's preface and gives
+                alternative title, Nagasaki Jitsuroku.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c6476decc0cc1d2d4a5395adbd927a6e">
+            <head>Immediate Source of Acquisition</head>
+            <p>From the library of Charles R. Boxer, London, England. <date normal="1973"
+                >1973.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_24578a9e25311371c94f969aa45b85d8" level="file">
+          <did>
+            <unittitle>Undated - Titherley, Arthur W. Two notes in Titherley's hand.</unittitle>
+            <physdesc id="aspace_9756213b78eedc1d7e8b35c57cef221a">Autograph notes 2 p.</physdesc>
+            <container id="aspace_e8b7ae516bbbb31bd8db4237327868d0" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_851e94f86468c89aaee8b1bce92f5404">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Francis Davison's <title render="italic">A poetical
+                  rapsody,</title> facsim. reprint of London: Printed by V.S. for John Baily, 1602
+                (1866?) (Lilly PR1207 .D3 1866).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_9a3581daee217979d4cd64e163a44f2b">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchase. Quaritch. <date normal="2006">2006.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_a757d72747cb0f7f7990a1f12830a9b0" level="file">
+          <did>
+            <unittitle>Undated - <persname>Toole, John Lawrence, 1830-1906, actor,
+                manager.</persname> Leicester. To Frederick William Hawkins. "I told you my Welsh
+              would make stir - it will be quoted a great deal which is good for your
+              Magazine...When do you want the article &amp; when do you want my
+              portrait?"</unittitle>
+            <physdesc id="aspace_d619ad3eb66efcdb9e54493d945de4a2">Autograph letter signed 2 p. 18
+              cm.</physdesc>
+            <container id="aspace_7545ed4f5b4a8b11e95d891fe5d54067" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_3c7618482f842fb1ba6d253ed61094bc">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Accompanied by a note on an envelope 10 x 12 cm.</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_02a5228a99ea3ce060701f0abfce7bbc">
+            <head>Immediate Source of Acquisition</head>
+            <p>Purchased. Ifan Kyrle Fletcher, 22 Buckingham Gate, London, S.W.1, England. <date
+                normal="1969">1969.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_0e68a423563133d2d0211f4f021a2b61" level="file">
+          <did>
+            <unittitle>Undated - <persname>Tournachon, Félix, 1820-1910, aeronaut.</persname> Paris,
+              France. To -- Dejolme. "...Veux tu me rendre le service d'inserer les 2 notes que
+              voici."</unittitle>
+            <physdesc id="aspace_7f8bb7edad2a19e56cf48771bc276921">Autograph letter signed 1 p. 21
+              cm.</physdesc>
+            <container id="aspace_ecfc3f1d5b6c8279b0c94abad8a558c2" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_f4f5f0d30286f8718ed61ecaa5564080">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from Vincenzo Lunardi's <title render="italic">An Account of the First
+                  Aerial Voyage in England...</title> London, 1784 (Lilly TL620 .L8 A27 copy
+                2).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_7261a26d7cb80269fb3a86419a6fb3da">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1959">1959.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_e0f1f54bd000a09a92bd1db74aef929b" level="file">
+          <did>
+            <unittitle>Undated - <persname>Tytler, Patrick Fraser, 1791-1849, historian.</persname>
+              36 Melville Street. To James Maidment, Princes Street. Thanks him for the printed copy
+              of an agreement made by the Boyd family to use in his History of Scotland and asks if
+              the original exists and where.</unittitle>
+            <physdesc id="aspace_11d37c86923b176f86ae135d193b2c9e">Autograph letter signed 1 p. 19
+              cm.</physdesc>
+            <container id="aspace_71cb29c6ce4d37dd106f870ea723024f" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_3a6f321e284641d3c20982838a8eb6f7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Removed from <title render="italic">An historical and critical essay on the life
+                  and character of Petrarch</title> by Alexander Fraser Tytler, lord Woodhousele.
+                Edinburgh, John Ballantyne and Co., 1810 (Lilly PQ4540 .W8).</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_918ba2c64109e68fa826d5646d3692d7">
+            <head>Immediate Source of Acquisition</head>
+            <p>Source unknown. <date normal="1967">1967.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_99c6f0507056725d0b5428581a2df0f2" level="file">
+          <did>
+            <unittitle>Undated - Waite, Arthur Edward, 1857-?. The False monarchy of
+              demons.</unittitle>
+            <physdesc id="aspace_2b40e7fbda0fcacf125057165d7f8320">Autograph document</physdesc>
+            <container id="aspace_fee5ea68619073f6f661410d49f9671e" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_19d23ba66510437e21e103253335b202">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>Handwritten copy</item>
+              <item>Includes diagrams in ink in front cover</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_c0f1dc838b2ac4e337b1d9cd9839534e">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Indianapolis Public Library. Indianapolis, Indiana. <date normal="1985"
+                >1985.</date></p>
+          </acqinfo>
+        </c02>
+        <c02 id="aspace_1e190c7bd038034852532e77194cda60" level="file">
+          <did>
+            <unittitle>Undated - The Wallop latch; ex lithographia, Medio-Montana.</unittitle>
+            <physdesc id="aspace_f09dfea4da3c2184bddceeab280c6559">Autograph document signed 18
+              p.</physdesc>
+            <container id="aspace_a751842602acaa771ebb4b7b0190a9eb" label="box" type="box"
+              >11</container>
+          </did>
+          <scopecontent id="aspace_71153c441b60b1c55fa1810b8edd62f7">
+            <head>Scope and Content</head>
+            <list type="ordered">
+              <item>In manuscript signed by Richard Cotton and William Huggins as witnesses</item>
+            </list>
+          </scopecontent>
+          <acqinfo id="aspace_a6e80989f2eb8b2f672c43ce2cf1bac5">
+            <head>Immediate Source of Acquisition</head>
+            <p>Gift. Indianapolis Public Library. Indianapolis, Indiana. <date normal="1985"
+                >1985.</date></p>
+          </acqinfo>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
+</ead>

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -12,7 +12,8 @@ require 'arclight/normalized_title'
 require 'active_model/conversion' ## Needed for Arclight::Repository
 require 'active_support/core_ext/array/wrap'
 require 'arclight/digital_object'
-require 'arclight/year_range'
+# IU customization: allow for collection date ranges over 1,000 years
+require_relative '../../ngao/year_range'
 require 'arclight/repository'
 require 'arclight/traject/nokogiri_namespaceless_reader'
 require 'debug' ## Needed for debugging
@@ -230,7 +231,7 @@ to_field 'dimensions_tesim', extract_xpath('/ead/archdesc/did/physdesc/dimension
 to_field 'genreform_ssim', extract_xpath('/ead/archdesc/controlaccess/genreform')
 
 to_field 'date_range_isim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
-  range = Arclight::YearRange.new
+  range = ::Ngao::YearRange.new
   next range.years if accumulator.blank?
 
   ranges = accumulator.map(&:to_s)

--- a/lib/ngao/year_range.rb
+++ b/lib/ngao/year_range.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'arclight/year_range'
+
+module Ngao
+  class YearRange < Arclight::YearRange
+    # @param [String] `dates` in the form YYYY/YYYY
+    # @return [Array<Integer>] the set of years in the given range
+    def parse_range(dates)
+      return if dates.blank?
+
+      start_year, end_year = dates.split('/').map { |date| to_year_from_iso8601(date) }
+      return [start_year] if end_year.blank?
+      # Original in Arclight checks that date ranges can't be larger than 1000 years, we don't want that in NGAO
+      # raise ArgumentError, "Range is too large: #{dates}" if (end_year - start_year) > 1000
+      raise ArgumentError, "Range is inverted: #{dates}" unless start_year <= end_year
+
+      (start_year..end_year).to_a
+    end
+  end
+end


### PR DESCRIPTION
# Story
## 💄 Style actions box container

be950975e41f9ffddcea653f087e303389ac0194

This commit adding Rivet styling to the actions box container on the
collection show page.  All that was really done was converting the
dropdown buttons to the Rivet buttons and align some elements better.

## 💄 Styling on Collection overview section

ebb96d5b1eed372d89ec66221e59bfa7563c8786

This commit adds minor styles on the Collection overview section.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/26

## 💄 Styles the contstraints buttons on show page

49fafe15d7391e6b56f61f6e98e83ca51da39b99

This commit adds basic styling to the Start Over and Back to Search
butttons.

## 💄 Styling show page breadcrumbs

5e00e48d43a4be4473dc40acd05ce361c7f0f7ec

This commit styles the breadcrumbs to be in line with the rivet styles.

## 💄 Style request button

89744afa87a4dac2ad838fff81347d345249b24d

This commit will style the request button on the catalog show page to
match the Rivet primary button.

## 💄 Style pagination on catalog show

cf72804f08b902ce88cccf862d1846d9dc0ee9cb

This commit will add the pagination styling on the catalog show and also
DRY up the scss somewhat with extensions.


Ref:
- #26 

# Screenshots / Video
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/24d1c3fd-37db-46a9-9b5a-a059d832974f">

