### PR TITLE
⚙️ Override `/collections`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   get '/search_history', to: 'application#render404'
   delete '/search_history/clear', to: 'application#render404'
 
+  # OVERRIDE Arclight to add `level_ssim`
+  get 'collections' => 'catalog#index', defaults: { f: { level_ssim: ['Collection'] } }, as: :collections
+
   mount Blacklight::Engine => '/'
   mount Arclight::Engine => '/'
 


### PR DESCRIPTION
# Story

This commit will override Arclight's route for `/collections` to change `level` to `leve_ssim`.

# Expected Behavior Before Changes
Clicking the `Collections` link on the navbar would take you to a blank search.

# Expected Behavior After Changes
Clicking on the `Collections` link now takes you to a faceted search.

# Screenshots / Video

## Before
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/eae5b555-3fa4-42f2-a9c2-bd4f86d271cb">

## After
<img width="1464" alt="image" src="https://github.com/user-attachments/assets/ddc6a77c-4fb4-4011-9ae2-1af50bf4e96c">
