### PR TITLE
I68 hidden element has focusable content

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
     - 'lib/generators/arclight/templates/**/*'
     - 'lib/tasks/index.rake'
     - 'README.md'
+    - 'app/components/blacklight_range_limit/range_form_component.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -333,6 +333,20 @@
   }
 
   #facets {
+    h3 button:focus {
+      @extend .rvt-button:focus;
+    }
+
+    h3 button:hover {
+      @extend .rvt-button:hover;
+    }
+
+    h3 button:active {
+      @extend .rvt-button:active;
+
+      border-color: var(--rvt-color-blue-400) !important;
+    }
+
     .facets-heading {
       font-size: 1.5rem;
     }
@@ -352,6 +366,32 @@
 
         .selected {
           color: var(--rvt-color-crimson-500) !important;
+        }
+      }
+    }
+
+    #facet-date_range_isim {
+      .input-group {
+        @extend .rvt-input-group;
+
+        #range_date_range_isim_begin {
+          @extend .rvt-input;
+
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        #range_date_range_isim_end {
+          @extend .rvt-input;
+
+          border-radius: 0
+        }
+
+        .btn-secondary {
+          @extend .rvt-button;
+
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
         }
       }
     }

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -1,0 +1,22 @@
+<%#
+  OVERRIDE Blacklight Range Limit v8.5.0 to swap the submit button in the div.visually-hidden with
+  the submit buton that is not in the div.visually-hidden.  Also adding tabindex="-1" to the hidden one.
+  This will pass the Siteimprove Accessibility Checker.
+%>
+
+<%= form_tag search_action_path, method: :get, class: [@classes[:form], "range_#{@facet_field.key} d-flex justify-content-center"].join(' ') do %>
+  <%= render hidden_search_state %>
+
+  <div class="input-group input-group-sm mb-3 flex-nowrap range-limit-input-group">
+    <%= render_range_input(:begin, begin_label) %>
+    <%= render_range_input(:end, end_label) %>
+    <div class="input-group-append visually-hidden">
+      <%# OVERRIDE begin %>
+      <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit] + " sr-only", "aria-hidden": "true", name: nil, tabindex: "-1" %>
+      <%# OVERRIDE end %>
+    </div>
+    <%# OVERRIDE begin %>
+    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], name: nil %>
+    <%# OVERRIDE end %>
+  </div>
+<% end %>

--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight Range Limit v8.5.0 to support the erb change, nothing in this class was changed
+
+module BlacklightRangeLimit
+  class RangeFormComponent < Blacklight::Component
+    delegate :search_action_path, to: :helpers
+
+    def initialize(facet_field:, classes: BlacklightRangeLimit.classes)
+      @facet_field = facet_field
+      @classes = classes
+    end
+
+    def begin_label
+      range_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: @facet_field.label)
+    end
+
+    def end_label
+      range_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: @facet_field.label)
+    end
+
+    def maxlength
+      range_config[:maxlength]
+    end
+
+    # type is 'begin' or 'end'
+    def render_range_input(type, input_label = nil, maxlength_override = nil)
+      type = type.to_s
+
+      default = if @facet_field.selected_range.is_a?(Range)
+                  case type
+                  when 'begin' then @facet_field.selected_range.first
+                  when 'end' then @facet_field.selected_range.last
+                  end
+                end
+
+      html = number_field_tag("range[#{@facet_field.key}][#{type}]", default, maxlength: maxlength_override || maxlength, class: "form-control text-center range_#{type}")
+      html += label_tag("range[#{@facet_field.key}][#{type}]", input_label, class: 'sr-only visually-hidden') if input_label.present?
+      html
+    end
+
+    private
+
+    ##
+    # the form needs to serialize any search parameters, including other potential range filters,
+    # as hidden fields. The parameters for this component's range filter are serialized as number
+    # inputs, and should not be in the hidden params.
+    # @return [Blacklight::HiddenSearchStateComponent]
+    def hidden_search_state
+      hidden_search_params = @facet_field.search_state.params_for_search.except(:utf8, :page)
+      hidden_search_params[:range]&.except!(@facet_field.key)
+      Blacklight::HiddenSearchStateComponent.new(params: hidden_search_params)
+    end
+
+    def range_config
+      @facet_field.range_config
+    end
+  end
+end


### PR DESCRIPTION
# Story

## ♿️ Override Range Limit gem for accessibility

b5c4aa24194f5e6aa793c0f160620710238a6627

This commit will override the Blacklight Range Limit v8.5.0 to swap the
submit button in the div.visually-hidden with the submit buton that is
not in the div.visually-hidden.  Also adding tabindex="-1" to the hidden
one. This will pass the Siteimprove Accessibility Checker.

The entire RangeFormComponent class had to be brought over because in
view components, we can't just bring over the view we want to override.
I am adding the class to the rubocop ignore because I don't want to
alter the contents since it's only here to support its view file to be
loaded.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/68

## 💄 Add visual feedback to facets for keyboard

a2e4eed93aeeae26d5d6f655a983d5b525e2a9db

Prior to this commit, when tabbing through the facets, there was no
visual feedback to indicate that the facet was focused. This commit will
add styling to the facets and also the date range inputs to align with
the Rivet design system.

# Screenshots / Video

https://github.com/user-attachments/assets/8b96be6c-e1ae-47db-919a-676f58171d33

# Notes
The button on the range limit facet should have been a secondary, but it looked really ugly so I made it a primary.