### PR TITLE
⚙️ Revert the Arclight route override

### DIFF
--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -1,0 +1,12 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to alter the link for `Collections`
+%>
+
+<li class="nav-item <%= repositories_active_class %>">
+  <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path, class: 'nav-link' %>
+</li>
+<li class="nav-item ml-3 ms-3 <%= collection_active_class %>">
+  <%# OVERRIDE begin %>
+  <%= link_to t('arclight.routes.collections'), '/catalog?f[level_ssim][]=Collection', class: 'nav-link' %>
+  <%# OVERRIDE end %>
+</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,6 @@ Rails.application.routes.draw do
   get '/search_history', to: 'application#render404'
   delete '/search_history/clear', to: 'application#render404'
 
-  # OVERRIDE Arclight to add `level_ssim`
-  get 'collections' => 'catalog#index', defaults: { f: { level_ssim: ['Collection'] } }, as: :collections
-
   mount Blacklight::Engine => '/'
   mount Arclight::Engine => '/'
 


### PR DESCRIPTION
This commit will revert a previous override of the Arclight route that changes the default params from `level` to `level_ssim`.  That solved the issue for the `Collections` link pointing to the correct faceted search, it broke all other facet searches.  If I changed the route directly in Arclight to add the `level_ssim` param, it worked fine.  If I brought it in locally then the other facets break.  I'm not sure why it was doing that but with regards to time, I going to override the link of the `Collections` to the correct faceted search.