### PR TITLE
♿️ Increase clickable area of breadcrumbs

### DIFF
--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -21,6 +21,7 @@
     }
 
     .breadcrumb-item {
+      height: 1.5rem;
       a[href="/"] {
         position: relative;
         display: inline-flex;
@@ -515,6 +516,7 @@
 
     .breadcrumb-campus-link {
       margin-left: 1rem;
+      height: 1.5rem;
     }
 
     .breadcrumb-item-1 {


### PR DESCRIPTION
This commit will add a 1.5rem (24px) height to all breadcrumb links for better accessibility and usability.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/66