### PR TITLE
💄 All text links must be underlined

### DIFF
--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -82,6 +82,11 @@
   }
 }
 
+// All a tags
+a {
+  text-decoration: underline !important;
+}
+
 // NAVBAR SEARCH
 .navbar-search {
   margin-bottom: 0.75rem;
@@ -477,12 +482,6 @@
   }
 
   .breadcrumb {
-    a {
-      text-decoration: none;
-      &:hover {
-        text-decoration: underline;
-      }
-    }
     .breadcrumb-home-link {
       a[href="/"] {
         position: relative;


### PR DESCRIPTION
This commit will add an underline for all text links in the app.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/70

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/cc76e78a-d727-4b00-a41a-c42a9bbba080">
