### PR TITLE
♿️ Don't render an empty breadcrumb element

### DIFF
--- a/app/components/ngao/arclight/search_result_breadcrumbs_component.html.erb
+++ b/app/components/ngao/arclight/search_result_breadcrumbs_component.html.erb
@@ -1,0 +1,13 @@
+<%#
+  OVERRIDE Arclight v1.4.0 to check if the rendered breadcrumbs is an empty html tag
+%>
+
+<dt class="visually-hidden">Collection Context</dt>
+
+<% if rendered_breadcrumbs.include? 'breadcrumb-item' %>
+  <dd>
+    <div class='breadcrumb-links'>
+      <%= rendered_breadcrumbs %>
+    </div>
+  </dd>
+<% end %>

--- a/app/components/ngao/arclight/search_result_breadcrumbs_component.rb
+++ b/app/components/ngao/arclight/search_result_breadcrumbs_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Ngao
+  module Arclight
+    class SearchResultBreadcrumbsComponent < ::Arclight::SearchResultBreadcrumbsComponent
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -188,7 +188,8 @@ class CatalogController < ApplicationController
     config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true,
                                                 helper_method: :render_html_tags,
                                                 component: Arclight::IndexMetadataFieldComponent
-    config.add_index_field 'breadcrumbs', accessor: :itself, component: Arclight::SearchResultBreadcrumbsComponent,
+    config.add_index_field 'breadcrumbs', accessor: :itself,
+                                          component: Ngao::Arclight::SearchResultBreadcrumbsComponent,
                                           compact: { count: 2 }
 
     config.add_facet_field 'access', query: {


### PR DESCRIPTION
This commit will guard against rendering an empty breadcrumb element when there are no breadcrumbs to display.  The check we are doing is to see if the html string has the `breadcrumb-item` class.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/67

Before:
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/2b28128d-8f66-45e3-9402-f333f3d2799e">

After:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/96febcf9-5d35-4ede-b08b-dc08900c67a0">
