### PR TITLE
🐛 Add group=true to collections link

### DIFF
--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -7,6 +7,6 @@
 </li>
 <li class="nav-item ml-3 ms-3 <%= collection_active_class %>">
   <%# OVERRIDE begin %>
-  <%= link_to t('arclight.routes.collections'), '/catalog?f[level_ssim][]=Collection', class: 'nav-link' %>
+  <%= link_to t('arclight.routes.collections'), '/catalog?f[level_ssim][]=Collection&group=true', class: 'nav-link' %>
   <%# OVERRIDE end %>
 </li>


### PR DESCRIPTION
In the previous commit where we override main_menu_links, I forgot to add group=true onto it.