### PR TITLE
♿️ Increase interactive element size

### DIFF
--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -407,6 +407,12 @@ a {
     .badge {
       @extend .rvt-badge, .rvt-badge--secondary;
     }
+
+    .al-grouped-repository a {
+      display: inline-block;
+      min-width: 1.5rem;
+      min-height: 1.5rem;
+    }
   }
 
   .record-padding {
@@ -415,6 +421,12 @@ a {
 
   .document-metadata {
     @extend %breadcrumb-styles;
+
+    .breadcrumb-item a {
+      display: inline-block;
+      min-width: 1.5rem;
+      min-height: 1.5rem;
+    }
   }
 }
 


### PR DESCRIPTION
This commit will increase the size of the breadcrumb links and repository links to make them at least 24x24 pixels.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/79

<img width="455" alt="image" src="https://github.com/user-attachments/assets/2a3f6d28-9562-40b4-8c81-26c4b29cc442">

<img width="350" alt="image" src="https://github.com/user-attachments/assets/6d91ea2c-c3d5-475f-a1fb-4c3ce9b1ac5d">
