### PR TITLE
♿️ Stop search text from clipping

### DIFF
--- a/app/assets/stylesheets/overrides_with_rivet_styles.scss
+++ b/app/assets/stylesheets/overrides_with_rivet_styles.scss
@@ -289,6 +289,12 @@ a {
 
 // SEARCH RESULTS PAGE
 .blacklight-catalog-index {
+  .applied-filter .constraint-value {
+    max-width: 100%;
+    overflow: unset;
+    white-space: normal;
+  }
+
   .btn-primary {
     @extend .rvt-button;
   }


### PR DESCRIPTION
This commit will remove the hidden overflow on the search contraints on the catalog search page when doing a faceted search.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/80

Before:
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/98a05a8b-c617-4b28-ae56-02d3a452805d">

After:
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/d7362155-86d0-421e-98be-0edc7bd5ff33">
