### PR TITLE
I81 responsive uv

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -3,10 +3,6 @@ $logo-image: image_url('arclight/logo.png') !default;
 @import 'bootstrap';
 @import 'blacklight/blacklight';
 @import 'arclight/application';
-@import 'breadcrumbs';
-@import 'campus';
-@import 'scroll_to_top';
-@import 'overrides_with_rivet_styles';
 
 body {
   min-height: 100vh;

--- a/app/assets/stylesheets/uv.scss
+++ b/app/assets/stylesheets/uv.scss
@@ -1,0 +1,7 @@
+// Make the universal viewer iframe responsive
+
+.blacklight-catalog-show {
+  #main-container iframe {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## 💄 Make UV responsive to viewport width

67d5301ec2e9809d9210791363efa7178bb4e766

This comit will make the UV viewer responsive to the viewport width.
This will prevent the UV from being too far off to the right of the
screen and forcing a horizontal scroll bar.

Ref:
- https://github.com/scientist-softserv/archives_online/issues/81

## 🧹 Remove uneeded imports

f039b48cde32cdcd04cb1dde5a63d3e1b48f4d36

The arclight.scss automatically imports the other scss files so we don't
need an extra import.  In fact, this was double importing the styles
making the styles appear twice in the compiled css.

https://github.com/user-attachments/assets/4d149588-1be4-43cd-ade5-7ff2c1f466d0
