### PR TITLE
🐛 i199 custom label for odd

### DIFF
--- a/app/components/ngao/blacklight/metadata_field_layout_component_decorator.rb
+++ b/app/components/ngao/blacklight/metadata_field_layout_component_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight MetadataFieldLayoutComponentDecorator v8.3.0 to render custom labels when they exist
+# When this component is initialized, `@key = @field.key.parameterize` is not splitting some of the keys properly
+
+module Ngao
+  module Blacklight
+    module MetadataFieldLayoutComponentDecorator
+      def label
+        document = @field.document
+        heading_field = "#{@key}_heading_ssm"
+
+        label = document[heading_field]&.first
+
+        # Some EADs are coming back with the key as the Solr label rather than just the key
+        # For example, the "<odd>" EAD keys are coming back as "odd_html_tesm" rather than just "odd"
+        unless label.present?
+          heading_field = "#{@key.split('_').first}_heading_ssm"
+          label = document[heading_field]&.first
+        end
+
+        return super unless label
+
+        "#{label}:"
+      end
+    end
+  end
+end
+
+Blacklight::MetadataFieldLayoutComponent.prepend(Ngao::Blacklight::MetadataFieldLayoutComponentDecorator)


### PR DESCRIPTION
# Story: [i199] Ensuring custom labels are rendering at the item level

Ref:
- https://github.com/notch8/archives_online/issues/199

## Expected Behavior Before Changes

Items in the `<odd>` EAD tags were not rendering custom labels.

## Expected Behavior After Changes

Items in the `<odd>` EAD tags are rendering custom labels.

## Screenshots / Video

<details>
<summary>Image: Before - General note</summary>

![Screenshot 2025-05-13 at 4 05 53 PM](https://github.com/user-attachments/assets/400962e0-eaf8-44c2-94fc-f4cc1e634b52)

</details>

<details>
<summary>Image: After - Shelf Number</summary>

![Screenshot 2025-05-13 at 2 17 32 PM](https://github.com/user-attachments/assets/04131d08-50ef-4136-ae92-5877c7cdfd80)

</details>

## Notes

This commit adds a decorator for the metadata field layout component to render custom labels. The initializer on MetadataFieldLayoutComponent is not parsing some of the keys which was allowing the Solr label to get passed into the key. This fix is checking for the presence of a label, and if it not present, manually splitting the key to get the correct key. There may be a future fix within the EAD2 configurations.